### PR TITLE
Enable isolation support and fix native JAR resolution

### DIFF
--- a/websub-ballerina/src/websub/commons.bal
+++ b/websub-ballerina/src/websub/commons.bal
@@ -141,7 +141,7 @@ public class IntentVerificationRequest {
     #
     # + expectedTopic - The topic for which subscription should be accepted
     # + return - An `http:Response`, which to the hub verifying/denying intent to subscribe
-    public function buildSubscriptionVerificationResponse(string expectedTopic) returns http:Response {
+    public isolated function buildSubscriptionVerificationResponse(string expectedTopic) returns http:Response {
         return buildIntentVerificationResponse(self, MODE_SUBSCRIBE, expectedTopic);
     }
 
@@ -152,7 +152,7 @@ public class IntentVerificationRequest {
     #
     # + expectedTopic - The topic for which unsubscription should be accepted
     # + return - An `http:Response`, which to for the hub verifying/denying intent to unsubscribe
-    public function buildUnsubscriptionVerificationResponse(string expectedTopic) returns http:Response {
+    public isolated function buildUnsubscriptionVerificationResponse(string expectedTopic) returns http:Response {
         return buildIntentVerificationResponse(self, MODE_UNSUBSCRIBE, expectedTopic);
     }
 }
@@ -163,7 +163,7 @@ public class IntentVerificationRequest {
 # + mode - The mode (subscription/unsubscription) for which a request was sent
 # + topic - The intended topic for which subscription change should be verified
 # + return - An `http:Response`, which to the hub verifying/denying intent to subscripe/unsubscribe
-function buildIntentVerificationResponse(IntentVerificationRequest intentVerificationRequest, string mode,
+isolated function buildIntentVerificationResponse(IntentVerificationRequest intentVerificationRequest, string mode,
                                          string topic) returns http:Response {
     http:Response response = new;
     var decodedTopic = encoding:decodeUriComponent(intentVerificationRequest.topic, "UTF-8");
@@ -186,7 +186,7 @@ function buildIntentVerificationResponse(IntentVerificationRequest intentVerific
 # + request - The request received
 # + serviceType - The service for which the request was rceived
 # + return - An `error`, if an error occurred in extraction or signature validation failed or else `()`
-function processWebSubNotification(http:Request request, service serviceType) returns @tainted error? {
+isolated function processWebSubNotification(http:Request request, service serviceType) returns @tainted error? {
     SubscriberServiceConfiguration? subscriberConfig = retrieveSubscriberServiceAnnotations(serviceType);
     string secret = subscriberConfig?.secret ?: "";
     // Build the data source before responding to the content delivery requests automatically
@@ -219,7 +219,7 @@ function processWebSubNotification(http:Request request, service serviceType) re
 # + stringPayload - The string representation of the notification payload received
 # + secret - The secret used when subscribing
 # + return - An `error`, if an error occurred in extraction or signature validation failed or else `()`
-function validateSignature(string xHubSignature, string stringPayload, string secret) returns error? {
+isolated function validateSignature(string xHubSignature, string stringPayload, string secret) returns error? {
     string[] splitSignature = stringutils:split(xHubSignature, "=");
     string method = splitSignature[0];
     string signature = stringutils:replace(xHubSignature, method + "=", "");
@@ -252,7 +252,7 @@ public class Notification {
     # ```
     #
     # + return - String-constrained array map of the query params
-    public function getQueryParams() returns map<string[]> {
+    public isolated function getQueryParams() returns map<string[]> {
         return self.request.getQueryParams();
     }
 
@@ -262,7 +262,7 @@ public class Notification {
     # ```
     #
     # + return - The `mime:Entity` of the request or else an `error` if entity construction fails
-    public function getEntity() returns mime:Entity|error {
+    public isolated function getEntity() returns mime:Entity|error {
         return self.request.getEntity();
     }
 
@@ -273,7 +273,7 @@ public class Notification {
     #
     # + headerName - The header name
     # + return - `true` if the specified header key exists or else `false`
-    public function hasHeader(string headerName) returns boolean {
+    public isolated function hasHeader(string headerName) returns boolean {
         return self.request.hasHeader(headerName);
     }
 
@@ -286,7 +286,7 @@ public class Notification {
     # + headerName - The header name
     # + return - The first header value for the specified header name or else panic if no header is found. Ideally, the
     #            `Notification.hasHeader()` needs to be used to check the existence of a header initially.
-    public function getHeader(string headerName) returns @tainted string {
+    public isolated function getHeader(string headerName) returns @tainted string {
         return self.request.getHeader(headerName);
     }
 
@@ -298,7 +298,7 @@ public class Notification {
     # + headerName - The header name
     # + return - The header values the specified header key maps to or else panic if no header is found. Ideally, the
     #            `Notification.hasHeader()` needs to be used to check the existence of a header initially.
-    public function getHeaders(string headerName) returns @tainted string[] {
+    public isolated function getHeaders(string headerName) returns @tainted string[] {
         return self.request.getHeaders(headerName);
     }
 
@@ -308,7 +308,7 @@ public class Notification {
     # ```
     #
     # + return - An array of all the header names
-    public function getHeaderNames() returns @tainted string[] {
+    public isolated function getHeaderNames() returns @tainted string[] {
         return self.request.getHeaderNames();
     }
 
@@ -318,7 +318,7 @@ public class Notification {
     # ```
     #
     # + return - The `content-type` header value as a `string`
-    public function getContentType() returns @tainted string {
+    public isolated function getContentType() returns @tainted string {
         return self.request.getContentType();
     }
 
@@ -329,7 +329,7 @@ public class Notification {
     #
     # + return - The `json` payload or else an `error` in case of errors.
     #            If the content; type is not JSON, an `error` is returned.
-    public function getJsonPayload() returns @tainted json|error {
+    public isolated function getJsonPayload() returns @tainted json|error {
         return self.request.getJsonPayload();
     }
 
@@ -340,7 +340,7 @@ public class Notification {
     #
     # + return - The `xml` payload or else an `error` in case of errors.
     #            If the content; type is not XML, an `error` is returned.
-    public function getXmlPayload() returns @tainted xml|error {
+    public isolated function getXmlPayload() returns @tainted xml|error {
         return self.request.getXmlPayload();
     }
 
@@ -351,7 +351,7 @@ public class Notification {
     #
     # + return - The payload as a `text` or else  an `error` in case of errors.
     #            If the content type is not of type text, an `error` is returned.
-    public function getTextPayload() returns @tainted string|error {
+    public isolated function getTextPayload() returns @tainted string|error {
         return self.request.getTextPayload();
     }
 
@@ -361,7 +361,7 @@ public class Notification {
     # ```
     #
     # + return - A byte channel from which the message payload can be read or esle an `error` in case of errors
-    public function getByteChannel() returns @tainted io:ReadableByteChannel|error {
+    public isolated function getByteChannel() returns @tainted io:ReadableByteChannel|error {
         return self.request.getByteChannel();
     }
 
@@ -371,7 +371,7 @@ public class Notification {
     # ```
     #
     # + return - The message payload as a `byte[]` or else an `error` in case of errors
-    public function getBinaryPayload() returns @tainted byte[]|error {
+    public isolated function getBinaryPayload() returns @tainted byte[]|error {
         return self.request.getBinaryPayload();
     }
 
@@ -381,7 +381,7 @@ public class Notification {
     # ```
     #
     # + return - The form params as a `map` or else an `error` in case of errors
-    public function getFormParams() returns @tainted map<string>|error {
+    public isolated function getFormParams() returns @tainted map<string>|error {
         return self.request.getFormParams();
     }
 }
@@ -582,7 +582,7 @@ public class Hub {
     # Users of the `ballerina/websub` module must use the function `startHub()` to initialize a `websub:Hub`
     # object instead of directly calling the initializer method.
     @deprecated
-    public function init(string subscriptionUrl, string publishUrl, http:Listener hubHttpListener) {
+    public isolated function init(string subscriptionUrl, string publishUrl, http:Listener hubHttpListener) {
          self.subscriptionUrl = subscriptionUrl;
          self.publishUrl = publishUrl;
          self.hubHttpListener = hubHttpListener;
@@ -594,7 +594,7 @@ public class Hub {
     # ```
     #
     # + return - An `error` if hub can't be stoped or else `()`
-    public function stop() returns error? {
+    public isolated function stop() returns error? {
         var stopResult = self.hubHttpListener.__gracefulStop();
         var stopHubServiceResult = stopHubService(self);
 
@@ -621,7 +621,7 @@ public class Hub {
     # + payload - The update payload
     # + contentType - The content type header to set for the request delivering the payload
     # + return - An `error` if the hub is not initialized or does not represent the internal hub or else `()`
-    public function publishUpdate(string topic, string|xml|json|byte[]|io:ReadableByteChannel payload,
+    public isolated function publishUpdate(string topic, string|xml|json|byte[]|io:ReadableByteChannel payload,
                                   string? contentType = ()) returns error? {
         if (self.publishUrl == "") {
             return WebSubError("Internal Ballerina Hub not initialized or incorrectly referenced");
@@ -700,7 +700,7 @@ public class Hub {
     # ```
     #
     # + return - An array of available topics
-    public function getAvailableTopics() returns string[] {
+    public isolated function getAvailableTopics() returns string[] {
             return externGetAvailableTopics(self);
     }
 
@@ -711,17 +711,17 @@ public class Hub {
     #
     # + topic - The topic for which details need to be retrieved
     # + return - An array of subscriber details
-    public function getSubscribers(string topic) returns SubscriberDetails[] {
+    public isolated function getSubscribers(string topic) returns SubscriberDetails[] {
         return externGetSubscribers(self, topic);
     }
 }
 
-function externGetAvailableTopics(Hub hub) returns string[] = @java:Method {
+isolated function externGetAvailableTopics(Hub hub) returns string[] = @java:Method {
     name: "getAvailableTopics",
     'class: "org.ballerinalang.net.websub.nativeimpl.HubNativeOperationHandler"
 } external;
 
-function externGetSubscribers(Hub hub, string topic) returns SubscriberDetails[] = @java:Method {
+isolated function externGetSubscribers(Hub hub, string topic) returns SubscriberDetails[] = @java:Method {
     name: "getSubscribers",
     'class: "org.ballerinalang.net.websub.nativeimpl.HubNativeOperationHandler"
 } external;
@@ -734,7 +734,7 @@ function externGetSubscribers(Hub hub, string topic) returns SubscriberDetails[]
 # + response - The response being sent
 # + hubs - The hubs the publisher advertises as the hubs that it publishes updates to
 # + topic - The topic to which subscribers need to subscribe to, to receive updates for the resource
-public function addWebSubLinkHeader(http:Response response, string[] hubs, string topic) {
+public isolated function addWebSubLinkHeader(http:Response response, string[] hubs, string topic) {
     string hubLinkHeader = "";
     foreach var hub in hubs {
         hubLinkHeader = hubLinkHeader + "<" + hub + ">; rel=\"hub\", ";
@@ -757,7 +757,7 @@ public type SubscriptionDetails record {|
     int createdAt = 0;
 |};
 
-function retrieveSubscriberServiceAnnotations(service serviceType) returns SubscriberServiceConfiguration? {
+isolated function retrieveSubscriberServiceAnnotations(service serviceType) returns SubscriberServiceConfiguration? {
     typedesc<any> serviceTypedesc = typeof serviceType;
     return serviceTypedesc.@SubscriberServiceConfig;
 }
@@ -785,7 +785,7 @@ type WebSubContent record {|
     string contentType = "";
 |};
 
-function isSuccessStatusCode(int statusCode) returns boolean {
+isolated function isSuccessStatusCode(int statusCode) returns boolean {
     return (200 <= statusCode && statusCode < 300);
 }
 

--- a/websub-ballerina/src/websub/hub_configuration.bal
+++ b/websub-ballerina/src/websub/hub_configuration.bal
@@ -42,7 +42,7 @@ boolean hubPersistenceEnabled = false;
 # Attaches and starts the Ballerina WebSub Hub service.
 #
 # + hubServiceListener - The `http:Listener` to which the service is attached
-function startHubService(http:Listener hubServiceListener) {
+isolated function startHubService(http:Listener hubServiceListener) {
     // TODO : handle errors
     checkpanic hubServiceListener.__attach(getHubService());
     checkpanic hubServiceListener.__start();
@@ -62,7 +62,7 @@ function isHubTopicRegistrationRequired() returns boolean {
     return hubTopicRegistrationRequired;
 }
 
-function getSignatureMethod(SignatureMethod? signatureMethod) returns string {
+isolated function getSignatureMethod(SignatureMethod? signatureMethod) returns string {
     match signatureMethod {
         "SHA256" => {
             return "SHA256";
@@ -74,6 +74,6 @@ function getSignatureMethod(SignatureMethod? signatureMethod) returns string {
     return DEFAULT_SIGNATURE_METHOD;
 }
 
-function getRemotePublishConfig(RemotePublishConfig? remotePublish) returns RemotePublishConfig {
+isolated function getRemotePublishConfig(RemotePublishConfig? remotePublish) returns RemotePublishConfig {
     return remotePublish is RemotePublishConfig ? remotePublish : {};
 }

--- a/websub-ballerina/src/websub/hub_persistence.bal
+++ b/websub-ballerina/src/websub/hub_persistence.bal
@@ -24,7 +24,7 @@ public type HubPersistenceStore object {
     #
     # + subscriptionDetails - The details of the subscription to add or update
     # + return - An `error` if an error occurred while adding the subscription or else `()` otherwise
-    public function addSubscription(SubscriptionDetails subscriptionDetails) returns error?;
+    public isolated function addSubscription(SubscriptionDetails subscriptionDetails) returns error?;
 
     # Removes subscription details.
     # ```ballerina
@@ -33,7 +33,7 @@ public type HubPersistenceStore object {
     #
     # + subscriptionDetails - The details of the subscription to remove
     # + return - An `error` if an error occurred while removing the subscription or else `()` otherwise
-    public function removeSubscription(SubscriptionDetails subscriptionDetails) returns error?;
+    public isolated function removeSubscription(SubscriptionDetails subscriptionDetails) returns error?;
 
     # Function to add a topic.
     # ```ballerina
@@ -42,7 +42,7 @@ public type HubPersistenceStore object {
     #
     # + topic - The topic to add
     # + return - An `error` if an error occurred while adding the topic or else `()` otherwise
-    public function addTopic(string topic) returns error?;
+    public isolated function addTopic(string topic) returns error?;
 
     # Function to remove a topic.
     # ```ballerina
@@ -51,7 +51,7 @@ public type HubPersistenceStore object {
     #
     # + topic - The topic to remove
     # + return - An `error` if an error occurred while removing the topic or else `()` otherwise
-    public function removeTopic(string topic) returns error?;
+    public isolated function removeTopic(string topic) returns error?;
 
     # Function to retrieve subscription details of all subscribers.
     # ```ballerina
@@ -60,7 +60,7 @@ public type HubPersistenceStore object {
     #
     # + return - An array of subscriber details or else an `error` if an error occurred while retrieving
     #            the subscriptions
-    public function retrieveAllSubscribers() returns SubscriptionDetails[]|error;
+    public isolated function retrieveAllSubscribers() returns SubscriptionDetails[]|error;
 
     # Function to retrieve all registered topics.
     # ```ballerina
@@ -68,5 +68,5 @@ public type HubPersistenceStore object {
     # ```
     #
     # + return - An array of topics or else `error` if an error occurred while retrieving the topics
-    public function retrieveTopics() returns string[]|error;
+    public isolated function retrieveTopics() returns string[]|error;
 };

--- a/websub-ballerina/src/websub/hub_service.bal
+++ b/websub-ballerina/src/websub/hub_service.bal
@@ -32,7 +32,7 @@ cache:CacheConfig config = {
 };
 cache:Cache subscriberCallbackClientCache = new(config);
 
-function getHubService() returns service {
+isolated function getHubService() returns service {
     return @http:ServiceConfig {
         basePath: hubBasePath,
         auth: hubServiceAuth
@@ -434,7 +434,7 @@ function addTopicRegistrationsOnStartup(HubPersistenceStore persistenceStore) re
     }
 }
 
-function addSubscriptionsOnStartup(HubPersistenceStore persistenceStore) returns error? {
+isolated function addSubscriptionsOnStartup(HubPersistenceStore persistenceStore) returns error? {
     SubscriptionDetails[]|error subscriptions = persistenceStore.retrieveAllSubscribers();
 
     if (subscriptions is SubscriptionDetails[]) {
@@ -584,7 +584,7 @@ class PendingSubscriptionChangeRequest {
     public string topic;
     public string callback;
 
-    public function init(string mode, string topic, string callback) {
+    public isolated function init(string mode, string topic, string callback) {
         self.mode = mode;
         self.topic = topic;
         self.callback = callback;
@@ -594,12 +594,12 @@ class PendingSubscriptionChangeRequest {
     #
     # + pendingRequest - The pending subscription change request to be checked against pending subscription or unsubscription
     # + return - A `boolean` indicating whether the requests are equal or not
-    function 'equals(PendingSubscriptionChangeRequest pendingRequest) returns boolean {
+    isolated function 'equals(PendingSubscriptionChangeRequest pendingRequest) returns boolean {
         return pendingRequest.mode == self.mode && pendingRequest.topic == self.topic && pendingRequest.callback == self.callback;
     }
 }
 
-function generateKey(string topic, string callback) returns (string) {
+isolated function generateKey(string topic, string callback) returns (string) {
     return topic + "_" + callback;
 }
 
@@ -608,7 +608,7 @@ function generateKey(string topic, string callback) returns (string) {
 # + hub - The hub publishing the update
 # + topic - The canonical URL of the topic for which the update occurred
 # + return - The link header content
-function buildWebSubLinkHeader(string hub, string topic) returns (string) {
+isolated function buildWebSubLinkHeader(string hub, string topic) returns (string) {
     string linkHeader = "<" + hub + ">; rel=\"hub\", <" + topic + ">; rel=\"self\"";
     return linkHeader;
 }
@@ -617,7 +617,7 @@ function buildWebSubLinkHeader(string hub, string topic) returns (string) {
 #
 # + groupString - Comma-separated string of groups
 # + return - An array of groups
-function getArray(string groupString) returns string[] {
+isolated function getArray(string groupString) returns string[] {
     string[] groupsArr = [];
     if (groupString.length() == 0) {
         return groupsArr;

--- a/websub-ballerina/src/websub/natives.bal
+++ b/websub-ballerina/src/websub/natives.bal
@@ -35,7 +35,7 @@ import ballerina/java;
 # + return - The newly-started hub or else a `websub:HubStartedUpError` if the hub is already started
 #            that the hub is already started, and including the WebSub Hub object representing the
 #            already started up hub
-function startUpHubService(string basePath, string subscriptionResourcePath, string publishResourcePath,
+isolated function startUpHubService(string basePath, string subscriptionResourcePath, string publishResourcePath,
                            boolean topicRegistrationRequired, string publicUrl, http:Listener hubListener)
                                     returns Hub|HubStartedUpError|HubStartupError = @java:Method {
     name: "startUpHubService",
@@ -46,14 +46,14 @@ function startUpHubService(string basePath, string subscriptionResourcePath, str
 #
 # + hub - The `websub:Hub` object returned when starting the hub
 # + return - `()` if the Ballerina Hub had been started and was stopped now or else an `error` otherwise
-function stopHubService(Hub hub) returns error? = @java:Method {
+isolated function stopHubService(Hub hub) returns error? = @java:Method {
     'class: "org.ballerinalang.net.websub.nativeimpl.HubNativeOperationHandler"
 } external;
 
 # Adds a new subscription for the specified topic in the Ballerina Hub.
 #
 # + subscriptionDetails - The details of the subscription including WebSub specifics
-function addSubscription(SubscriptionDetails subscriptionDetails) = @java:Method {
+isolated function addSubscription(SubscriptionDetails subscriptionDetails) = @java:Method {
     'class: "org.ballerinalang.net.websub.nativeimpl.HubNativeOperationHandler"
 } external;
 
@@ -62,7 +62,7 @@ function addSubscription(SubscriptionDetails subscriptionDetails) = @java:Method
 # + topic - The topic for which the update should happen
 # + content - The content to send to subscribers with the specified payload and content-type
 # + return - An `error` if an error occurred during publishing or esle `()`
-function publishToInternalHub(string topic, WebSubContent content) returns error? = @java:Method {
+isolated function publishToInternalHub(string topic, WebSubContent content) returns error? = @java:Method {
     name: "publishToInternalHub",
     'class: "org.ballerinalang.net.websub.nativeimpl.HubNativeOperationHandler"
 } external;
@@ -71,7 +71,7 @@ function publishToInternalHub(string topic, WebSubContent content) returns error
 #
 # + topic - The topic for which the subscription was added
 # + callback - The callback registered for this subscription
-function removeNativeSubscription(string topic, string callback) = @java:Method {
+isolated function removeNativeSubscription(string topic, string callback) = @java:Method {
     name: "removeNativeSubscription",
     'class: "org.ballerinalang.net.websub.nativeimpl.HubNativeOperationHandler"
 } external;
@@ -80,7 +80,7 @@ function removeNativeSubscription(string topic, string callback) = @java:Method 
 #
 # + topic - The topic to register
 # + return - An `error` if an error occurred during the registration
-function registerTopicAtNativeHub(string topic) returns error? = @java:Method {
+isolated function registerTopicAtNativeHub(string topic) returns error? = @java:Method {
    name: "registerTopicAtNativeHub",
    'class: "org.ballerinalang.net.websub.nativeimpl.HubNativeOperationHandler"
 } external;
@@ -89,7 +89,7 @@ function registerTopicAtNativeHub(string topic) returns error? = @java:Method {
 #
 # + topic - The topic to unregister
 # + return - An `error` if an error occurred during the unregistration
-function unregisterTopicAtNativeHub(string topic) returns error? = @java:Method {
+isolated function unregisterTopicAtNativeHub(string topic) returns error? = @java:Method {
     name: "unregisterTopicAtNativeHub",
     'class: "org.ballerinalang.net.websub.nativeimpl.HubNativeOperationHandler"
 } external;
@@ -98,7 +98,7 @@ function unregisterTopicAtNativeHub(string topic) returns error? = @java:Method 
 #
 # + topic - The topic to check
 # + return - `true` if the topic has been registered by a publisher or else `false`otherwise
-function isTopicRegistered(string topic) returns boolean = @java:Method {
+isolated function isTopicRegistered(string topic) returns boolean = @java:Method {
     name: "isTopicRegistered",
     'class: "org.ballerinalang.net.websub.nativeimpl.HubNativeOperationHandler"
 } external;
@@ -112,12 +112,12 @@ function isTopicRegistered(string topic) returns boolean = @java:Method {
 # + topic - The topic for which the update should happen
 # + content - The content to send to subscribers with the specified payload and content-type
 # + return - An `error` if an error occurred during publishing
-function validateAndPublishToInternalHub(string publishUrl, string topic, WebSubContent content)
+isolated function validateAndPublishToInternalHub(string publishUrl, string topic, WebSubContent content)
                                          returns error? = @java:Method {
     name: "validateAndPublishToInternalHub",
     'class: "org.ballerinalang.net.websub.nativeimpl.PublisherNativeOperationHandler"
 } external;
 
-function constructByteArray(io:ReadableByteChannel byteChannel) returns byte[] = @java:Method {
+isolated function constructByteArray(io:ReadableByteChannel byteChannel) returns byte[] = @java:Method {
     'class: "org.ballerinalang.net.websub.nativeimpl.PublisherNativeOperationHandler"
 } external;

--- a/websub-ballerina/src/websub/publisher_client.bal
+++ b/websub-ballerina/src/websub/publisher_client.bal
@@ -159,7 +159,7 @@ public client class PublisherClient {
 # + mode - Whether the request is for registration or unregistration
 # + topic - The topic to register/unregister
 # + return - An `http:Request` to be sent to the hub to register/unregister
-function buildTopicRegistrationChangeRequest(@untainted string mode, @untainted string topic) returns (http:Request) {
+isolated function buildTopicRegistrationChangeRequest(@untainted string mode, @untainted string topic) returns (http:Request) {
     http:Request request = new;
     request.setTextPayload(HUB_MODE + "=" + mode + "&" + HUB_TOPIC + "=" + topic);
     request.setHeader(CONTENT_TYPE, mime:APPLICATION_FORM_URLENCODED);

--- a/websub-ballerina/src/websub/subscriber_client.bal
+++ b/websub-ballerina/src/websub/subscriber_client.bal
@@ -81,7 +81,7 @@ public client class SubscriptionClient {
 # + subscriptionChangeRequest - The SubscriptionChangeRequest specifying the topic to subscribe and the
 #                               parameters to use
 # + return - An `http:Request` to be sent to the hub to subscribe/unsubscribe
-function buildSubscriptionChangeRequest(@untainted string mode,
+isolated function buildSubscriptionChangeRequest(@untainted string mode,
                                         SubscriptionChangeRequest subscriptionChangeRequest) returns (http:Request) {
     http:Request request = new;
 
@@ -198,7 +198,7 @@ function unsubscribeWithRetries(string url, SubscriptionChangeRequest unsubscrip
                               remainingRedirects);
 }
 
-function getRedirectionMaxCount(http:FollowRedirects? followRedirects) returns int {
+isolated function getRedirectionMaxCount(http:FollowRedirects? followRedirects) returns int {
     if (followRedirects is http:FollowRedirects) {
         if (followRedirects.enabled) {
             return followRedirects.maxCount;

--- a/websub-ballerina/src/websub/subscriber_service_caller.bal
+++ b/websub-ballerina/src/websub/subscriber_service_caller.bal
@@ -20,7 +20,7 @@ import ballerina/http;
 public client class Caller {
     private http:Caller httpCaller;
 
-    function init(http:Caller httpCaller) {
+    isolated function init(http:Caller httpCaller) {
         self.httpCaller = httpCaller;
     }
 
@@ -32,7 +32,7 @@ public client class Caller {
     # + message - The response or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`,
     #             or `mime:Entity[]`
     # + return - An `error` on failure or else `()`
-    public remote function respond(http:ResponseMessage message = ()) returns error? {
+    public isolated remote function respond(http:ResponseMessage message = ()) returns error? {
         return self.httpCaller->respond(message);
     }
 
@@ -44,7 +44,7 @@ public client class Caller {
     # + message - The response or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`,
     #             or `mime:Entity[]`
     # + return - An `error` on failure or else `()`
-    public remote function ok(http:ResponseMessage message = ()) returns error? {
+    public isolated remote function ok(http:ResponseMessage message = ()) returns error? {
         return self.httpCaller->ok(message);
     }
 
@@ -55,7 +55,7 @@ public client class Caller {
     #
     # + message - The response or any payload of the `http:ResponseMessage` type
     # + return - An `error` on failure or else `()`
-    public remote function accepted(http:ResponseMessage message = ()) returns error? {
+    public isolated remote function accepted(http:ResponseMessage message = ()) returns error? {
         return self.httpCaller->accepted(message);
     }
 }

--- a/websub-ballerina/src/websub/subscriber_service_endpoint.bal
+++ b/websub-ballerina/src/websub/subscriber_service_endpoint.bal
@@ -39,7 +39,7 @@ public class Listener {
     #
     # + port - The port number of the remote service
     # + config - The configurations related to the `websub:Listener`
-    public function init(int port, SubscriberListenerConfiguration? config = ()) {
+    public isolated function init(int port, SubscriberListenerConfiguration? config = ()) {
         self.config = config;
         http:ListenerConfiguration? serviceConfig = ();
         if (config is SubscriberListenerConfiguration) {
@@ -63,7 +63,7 @@ public class Listener {
     # + s - Type descriptor of the service
     # + name - Name of the service
     # + return - `()` or else an `error` upon failure to register the listener
-    public function __attach(service s, string? name = ()) returns error? {
+    public isolated function __attach(service s, string? name = ()) returns error? {
         // TODO: handle data and return error on error
         externRegisterWebSubSubscriberService(self, s);
     }
@@ -75,7 +75,7 @@ public class Listener {
     #
     # + s - Type descriptor of the service
     # + return - `()` or else an `error` upon failure to detach the service
-    public function __detach(service s) returns error? {
+    public isolated function __detach(service s) returns error? {
     }
 
     # Starts the `websub:Listener`.
@@ -96,7 +96,7 @@ public class Listener {
     # ```
     #
     # + return - `()` or else an `error` upon failure to stop the listener
-    public function __gracefulStop() returns error? {
+    public isolated function __gracefulStop() returns error? {
         http:Listener? sListener = self.serviceEndpoint;
         if (sListener is http:Listener) {
             return sListener.__gracefulStop();
@@ -110,7 +110,7 @@ public class Listener {
     # ```
     #
     # + return - () or else an `error` upon failure to stop the listener
-    public function __immediateStop() returns error? {
+    public isolated function __immediateStop() returns error? {
     }
 
     # Sends subscription requests to the specified/discovered hubs if specified to subscribe on startup.
@@ -183,7 +183,7 @@ public class Listener {
     #
     # + webSubServiceName - The name of the service for which subscription happened for a topic
     # + topic - The topic the subscription happened for
-    function setTopic(string webSubServiceName, string topic) {
+    isolated function setTopic(string webSubServiceName, string topic) {
         externSetTopic(self, webSubServiceName, topic);
     }
 }
@@ -192,27 +192,27 @@ public class Listener {
 //////////////////// WebSub Subscriber Natives ////////////////////
 ///////////////////////////////////////////////////////////////////
 
-function externInitWebSubSubscriberServiceEndpoint(Listener subscriberListener) = @java:Method {
+isolated function externInitWebSubSubscriberServiceEndpoint(Listener subscriberListener) = @java:Method {
     name: "initWebSubSubscriberServiceEndpoint",
     'class: "org.ballerinalang.net.websub.nativeimpl.SubscriberNativeOperationHandler"
 } external;
 
-function externRegisterWebSubSubscriberService(Listener subscriberListener, service serviceType) = @java:Method {
+isolated function externRegisterWebSubSubscriberService(Listener subscriberListener, service serviceType) = @java:Method {
     name: "registerWebSubSubscriberService",
     'class: "org.ballerinalang.net.websub.nativeimpl.SubscriberNativeOperationHandler"
 } external;
 
-function externStartWebSubSubscriberServiceEndpoint(Listener subscriberListener) returns error? = @java:Method {
+isolated function externStartWebSubSubscriberServiceEndpoint(Listener subscriberListener) returns error? = @java:Method {
     name: "startWebSubSubscriberServiceEndpoint",
     'class: "org.ballerinalang.net.websub.nativeimpl.SubscriberNativeOperationHandler"
 } external;
 
-function externSetTopic(Listener subscriberListener, string webSubServiceName, string topic) = @java:Method {
+isolated function externSetTopic(Listener subscriberListener, string webSubServiceName, string topic) = @java:Method {
     name: "setTopic",
     'class: "org.ballerinalang.net.websub.nativeimpl.SubscriberNativeOperationHandler"
 } external;
 
-function externRetrieveSubscriptionParameters(Listener subscriberListener) returns map<any>[] = @java:Method {
+isolated function externRetrieveSubscriptionParameters(Listener subscriberListener) returns map<any>[] = @java:Method {
     name: "retrieveSubscriptionParameters",
     'class: "org.ballerinalang.net.websub.nativeimpl.SubscriberNativeOperationHandler"
 } external;

--- a/websub-native/build.gradle
+++ b/websub-native/build.gradle
@@ -24,9 +24,9 @@ description = 'Ballerina - Websub Java Utils'
 dependencies {
     compile group: 'org.ballerinalang', name: 'ballerina-lang', version: "${ballerinaLangVersion}"
     compile group: 'org.ballerinalang', name: 'ballerina-runtime', version: "${ballerinaLangVersion}"
-    compile group: 'org.ballerinalang', name: 'ballerina-http', version: "${ballerinaLangVersion}"
-    compile group: 'org.ballerinalang', name: 'ballerina-mime', version: "${ballerinaLangVersion}"
-    compile group: 'org.ballerinalang', name: 'ballerina-io', version: "${ballerinaLangVersion}"
+    compile group: 'org.ballerinalang', name: 'http-native', version: "${stdlibHttpVersion}"
+    compile group: 'org.ballerinalang', name: 'mime-native', version: "${stdlibMimeVersion}"
+    compile group: 'org.ballerinalang', name: 'io-native', version: "${stdlibIoVersion}"
     compile group: 'org.ballerinalang', name: 'value', version: "${ballerinaLangVersion}"
     compile group: 'org.ballerinalang', name: 'typedesc', version: "${ballerinaLangVersion}"
     compile group: 'org.ballerinalang', name: 'toml-parser', version: "${ballerinaTomlParserVersion}"


### PR DESCRIPTION
## Purpose
$subject

**Approach**
- The Ballerina hub related APIs can be mark as isolated since we are using a static hub.
- As we did in socket and HTTP, here the publisher and subscriber APIs can be isolated since those work independently without accessing any shared resources.
- Fix Stdlib native JAR resolution

## Test environment
- macOS
- Java 8
- SLP4
