### PR TITLE
Trigger stdlib dependency update workflow only for master branch

### DIFF
--- a/.github/workflows/stdlib-workflow-trigger.yml
+++ b/.github/workflows/stdlib-workflow-trigger.yml
@@ -2,6 +2,8 @@ name: Stdlib Dependency Update
 
 on:
   push:
+    branches: 
+      - master
     paths:
     - 'build.gradle'
     - 'gradle.properties'

--- a/.github/workflows/stdlib-workflow-trigger.yml
+++ b/.github/workflows/stdlib-workflow-trigger.yml
@@ -5,8 +5,8 @@ on:
     branches: 
       - master
     paths:
-    - 'build.gradle'
-    - 'gradle.properties'
+      - 'build.gradle'
+      - 'gradle.properties'
 
 jobs:
   trigger-workflow:


### PR DESCRIPTION
## Purpose
Trigger stdlib dependency update workflow only when `build.gradle` file or `gradle.properties` file is updated in the master branch
