### PR TITLE
Add content negotiation

### DIFF
--- a/websub-ballerina/annotation.bal
+++ b/websub-ballerina/annotation.bal
@@ -25,6 +25,8 @@ import ballerina/http;
 # + subscribeOnStartUp - A `boolean` indicating whether a subscription request is expected to be sent on start up
 # + target - The `string` resource URL for which discovery will be initiated to identify the hub and topic,
 #               or a tuple `[hub, topic]` representing a discovered hub and a topic
+# + accept - The expected media type
+# + acceptLanguage - The expected language type
 # + leaseSeconds - The period for which the subscription is expected to be active
 # + secret - The secret to be used for authenticated content distribution
 # + callback - The callback to use when registering, if unspecified host:port/path will be used
@@ -35,6 +37,8 @@ public type SubscriberServiceConfiguration record {|
     string path?;
     boolean subscribeOnStartUp = true;
     string|[string, string] target?;
+    string|string[] accept?;
+    string|string[] acceptLanguage?;
     int leaseSeconds?;
     string secret?;
     string callback?;

--- a/websub-ballerina/commons.bal
+++ b/websub-ballerina/commons.bal
@@ -68,10 +68,14 @@ const string REMOTE_PUBLISHING_MODE_FETCH = "fetch";
 const string X_HUB_UUID = "X-Hub-Uuid";
 const string X_HUB_TOPIC = "X-Hub-Topic";
 
+const string ACCEPT_HEADER = "Accept";
+const string ACCEPT_LANGUAGE_HEADER = "Accept-Language";
 const string CONTENT_TYPE = "Content-Type";
 
 const string ANN_NAME_WEBSUB_SUBSCRIBER_SERVICE_CONFIG = "SubscriberServiceConfig";
 const ANNOT_FIELD_TARGET = "target";
+const ANNOT_FIELD_ACCEPT = "accept";
+const ANNOT_FIELD_ACCEPT_LANGUAGE = "acceptLanguage";
 const ANNOT_FIELD_CALLBACK = "callback";
 const ANNOT_FIELD_LEASE_SECONDS = "leaseSeconds";
 const ANNOT_FIELD_SECRET = "secret";
@@ -394,7 +398,11 @@ public function extractTopicAndHubUrls(http:Response response) returns @tainted 
     if (response.hasHeader("Link")) {
         linkHeaders = response.getHeaders("Link");
     }
-
+    
+    if (response.statusCode == http:STATUS_NOT_ACCEPTABLE) {
+        return error WebSubError("Content negotiation failed.Accept and/or Accept-Language headers mismatch");
+    }
+    
     if (linkHeaders.length() == 0) {
         return error WebSubError("Link header unavailable in discovery response");
     }

--- a/websub-generic-integration-tests/tests/constants.bal
+++ b/websub-generic-integration-tests/tests/constants.bal
@@ -34,6 +34,22 @@ const string WEBSUB_TOPIC_FOUR = "http://four.websub.topic.com";
 const string WEBSUB_TOPIC_FIVE = "http://one.redir.topic.com";
 const string WEBSUB_TOPIC_SIX = "http://two.redir.topic.com";
 
+const string HEADER_ACCEPT = "Accept";
+const string HEADER_ACCEPT_LANGUAGE = "Accept-Language";
+const string ID_MATCH_ACCEPT_AND_ACCEPT_LANGUAGE_HEADER_ARRAY = "MatchingAcceptAndAcceptLanguageHeaderArray";
+const string ID_MATCH_ACCEPT_AND_ACCEPT_LANGUAGE_HEADERS = "MatchingAcceptAndAcceptLanguageHeaders";
+const string ID_MATCH_ACCEPT_HEADER = "MatchingAcceptHeader";
+const string ID_MATCH_ACCEPT_LANGUAGE_HEADER = "MatchingAcceptLanguageHeader";
+const string ID_MISMATCH_ACCEPT_AND_ACCEPT_LANGUAGE_HEADER_ARRAY = "MisMatchingAcceptAcceptLanguageHeaderArray";
+const string ID_MISMATCH_ACCEPT_AND_ACCEPT_LANGUAGE_HEADERS = "MisMatchingAcceptAndAcceptLanguageHeaders";
+const string ID_MISMATCH_ACCEPT_HEADER = "MisMathingAcceptHeader";
+const string ID_MISMATCH_ACCEPT_LANGUAGE_HEADER = "MisMatchingAcceptLanguageHeader";
+const string ID_MISSING_ACCEPT_AND_ACCEPT_LANGUAGE_HEADERS = "MissingAcceptAndAcceptLanguageHeaders";
+const string LANGUAGE_TYPE_DE = "de-DE";
+const string RESPONSE_CODE_ACCEPTED = "202";
+const string RESPONSE_CODE_NOT_ACCEPTABLE = "406";
+const string RESPONSE_CODE_INTERNAL_SERVER_ERROR = "500";
+
 const string ID_INTENT_VER_REQ_RECEIVED_LOG = "IntentVerificationInvocation";
 const string ID_BY_KEY_CREATED_LOG = "DispatchingByKeyCreated";
 const string ID_BY_KEY_FEATURE_LOG = "DispatchingByKeyFeatured";

--- a/websub-generic-integration-tests/tests/test_content_negotiation.bal
+++ b/websub-generic-integration-tests/tests/test_content_negotiation.bal
@@ -1,0 +1,277 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/log;
+import ballerina/stringutils;
+import ballerina/test;
+import ballerina/websub;
+
+websub:Hub WebSubHub = startHubAndRegisterTopic();
+listener http:Listener publisherServiceEPOne = new http:Listener(24080);
+listener websub:Listener websubSubscriberEPOne = new websub:Listener(24081);
+listener websub:Listener websubSubscriberEPTwo = new websub:Listener(24082);
+listener websub:Listener websubSubscriberEPThree = new websub:Listener(24083);
+listener websub:Listener websubSubscriberEPFour = new websub:Listener(24084);
+listener websub:Listener websubSubscriberEPFive = new websub:Listener(24085);
+listener websub:Listener websubSubscriberEPSix = new websub:Listener(24086);
+listener websub:Listener websubSubscriberEPSeven = new websub:Listener(24087);
+listener websub:Listener websubSubscriberEPEight = new websub:Listener(24088);
+listener websub:Listener websubSubscriberEPNine = new websub:Listener(24089);
+
+service /publisherService on publisherServiceEPOne {
+    resource function get withAcceptAndAcceptLanguageHeaderArray(http:Caller caller, http:Request req) {
+        http:Response response = new;
+        if (!(req.hasHeader(HEADER_ACCEPT) && req.hasHeader(HEADER_ACCEPT_LANGUAGE))) {
+            response.statusCode = 500;
+            var result = caller->respond(response);
+            log:printError("Error responding", err = result);
+            storeOutput(ID_MISSING_ACCEPT_AND_ACCEPT_LANGUAGE_HEADERS, response.statusCode);
+        } else {
+            string mediaType = req.getHeader(HEADER_ACCEPT);
+            string languageType = req.getHeader(HEADER_ACCEPT_LANGUAGE);
+            if (stringutils:contains(mediaType, CONTENT_TYPE_JSON) && stringutils:contains(languageType, LANGUAGE_TYPE_DE)) {
+                websub:addWebSubLinkHeader(response, [WebSubHub.subscriptionUrl], WEBSUB_TOPIC_ONE);
+                response.statusCode = 202;
+                var result = caller->respond(response);
+                storeOutput(ID_MATCH_ACCEPT_AND_ACCEPT_LANGUAGE_HEADER_ARRAY, response.statusCode);
+                if (result is error) {
+                    log:printError("Error responding", err = result);
+                }
+            } else {
+                response.statusCode = 406;
+                var result = caller->respond(response);
+                log:printError("Error responding", err = result);
+                storeOutput(ID_MISMATCH_ACCEPT_AND_ACCEPT_LANGUAGE_HEADER_ARRAY, response.statusCode);
+            }
+        }
+    }
+
+    resource function get withAcceptAndAcceptLanguageHeaders(http:Caller caller, http:Request req) {
+        http:Response response = new;
+        if (!(req.hasHeader(HEADER_ACCEPT) && req.hasHeader(HEADER_ACCEPT_LANGUAGE))) {
+            response.statusCode = 500;
+            var result = caller->respond(response);
+            log:printError("Error responding", err = result);
+            storeOutput(ID_MISSING_ACCEPT_AND_ACCEPT_LANGUAGE_HEADERS, response.statusCode);
+        } else {
+             string mediaType = req.getHeader(HEADER_ACCEPT);
+             string languageType = req.getHeader(HEADER_ACCEPT_LANGUAGE);
+             if (mediaType == CONTENT_TYPE_JSON && languageType == LANGUAGE_TYPE_DE) {
+                 websub:addWebSubLinkHeader(response, [WebSubHub.subscriptionUrl], WEBSUB_TOPIC_ONE);
+                 response.statusCode = 202;
+                 var result = caller->respond(response);
+                 storeOutput(ID_MATCH_ACCEPT_AND_ACCEPT_LANGUAGE_HEADERS, response.statusCode);
+                 if (result is error) {
+                     log:printError("Error responding", err = result);
+                 }
+             } else {
+                response.statusCode = 406;
+                var result = caller->respond(response);
+                log:printError("Error responding", err = result);
+                storeOutput(ID_MISMATCH_ACCEPT_AND_ACCEPT_LANGUAGE_HEADERS, response.statusCode);
+            }
+        }
+    }
+
+    resource function get withAcceptHeader(http:Caller caller, http:Request req) {
+        http:Response response = new;
+        string mediaType = req.getHeader(HEADER_ACCEPT);
+        if (mediaType == CONTENT_TYPE_JSON) {
+            websub:addWebSubLinkHeader(response, [WebSubHub.subscriptionUrl], WEBSUB_TOPIC_ONE);
+            response.statusCode = 202;
+            var result = caller->respond(response);
+            storeOutput(ID_MATCH_ACCEPT_HEADER, response.statusCode);
+            if (result is error) {
+                log:printError("Error responding", err = result);
+            }
+        } else {
+            response.statusCode = 406;
+            var result = caller->respond(response);
+            log:printError("Error responding", err = result);
+            storeOutput(ID_MISMATCH_ACCEPT_HEADER, response.statusCode);
+        }
+    }
+
+    resource function get withAcceptLanguageHeader(http:Caller caller, http:Request req) {
+        http:Response response = new;
+        string languageType = req.getHeader(HEADER_ACCEPT_LANGUAGE);
+        if (languageType == LANGUAGE_TYPE_DE) {
+            websub:addWebSubLinkHeader(response, [WebSubHub.subscriptionUrl], WEBSUB_TOPIC_ONE);
+            response.statusCode = 202;
+            var result = caller->respond(response);
+            storeOutput(ID_MATCH_ACCEPT_LANGUAGE_HEADER, response.statusCode);
+            if (result is error) {
+                log:printError("Error responding", err = result);
+            }
+        } else {
+            response.statusCode = 406;
+            var result = caller->respond(response);
+            log:printError("Error responding", err = result);
+            storeOutput(ID_MISMATCH_ACCEPT_LANGUAGE_HEADER, response.statusCode);
+        }
+    }
+}
+
+// do nothing for every onNotification functions.Just for SubscriberServiceConfig annotation.Testing for new fields
+// of SubscriberServiceConfig annotation is done by checking status code of response from initial discovery request
+
+@websub:SubscriberServiceConfig {
+    subscribeOnStartUp: true,
+    target: "http://localhost:24080/publisherService/withAcceptAndAcceptLanguageHeaderArray",
+    accept: ["application/json", "application/xml", "text/html"],
+    acceptLanguage: ["de-DE", "de-US"],
+    leaseSeconds: 3600,
+    secret: "Kslk30SNF2AChs2"
+}
+service websub:SubscriberService /subcriberMatchingAcceptAndAcceptLanguageHeaderArray on websubSubscriberEPEight {
+    remote function onNotification(websub:Notification notification) {}
+}
+
+@websub:SubscriberServiceConfig {
+    subscribeOnStartUp: true,
+    target: "http://localhost:24080/publisherService/withAcceptAndAcceptLanguageHeaderArray",
+    accept: ["text/csv", "text/plain"],
+    acceptLanguage: ["en-US", "en-CA"],
+    leaseSeconds: 3600,
+    secret: "Kslk30SNF2AChs2"
+}
+service websub:SubscriberService /subcriberMisMatchingAcceptAndAcceptLanguageHeaderArray on websubSubscriberEPNine {
+    remote function onNotification(websub:Notification notification) {}
+}
+
+@websub:SubscriberServiceConfig {
+    subscribeOnStartUp: true,
+    target: "http://localhost:24080/publisherService/withAcceptAndAcceptLanguageHeaders",
+    accept: "application/json",
+    acceptLanguage: "de-DE",
+    leaseSeconds: 3600,
+    secret: "Kslk30SNF2AChs2"
+}
+service websub:SubscriberService /subcriberMatchingAcceptAndAcceptLanguageHeaders on websubSubscriberEPOne {
+    remote function onNotification(websub:Notification notification) {}
+}
+
+@websub:SubscriberServiceConfig {
+    subscribeOnStartUp: true,
+    target: "http://localhost:24080/publisherService/withAcceptAndAcceptLanguageHeaders",
+    accept: "text/html",
+    acceptLanguage: "de-US",
+    leaseSeconds: 3600,
+    secret: "Kslk30SNF2AChs2"
+}
+service websub:SubscriberService /subcriberMisMatchingAcceptAndAcceptLanguageHeaders on websubSubscriberEPTwo {
+    remote function onNotification(websub:Notification notification) {}
+}
+
+@websub:SubscriberServiceConfig {
+    subscribeOnStartUp: true,
+    target: "http://localhost:24080/publisherService/withAcceptHeader",
+    accept: "application/json",
+    leaseSeconds: 3600,
+    secret: "Kslk30SNF2AChs2"
+}
+service websub:SubscriberService /subcriberMatchingAcceptHeader on websubSubscriberEPThree {
+    remote function onNotification(websub:Notification notification) {}
+}
+
+@websub:SubscriberServiceConfig {
+    subscribeOnStartUp: true,
+    target: "http://localhost:24080/publisherService/withAcceptHeader",
+    accept: "text/html",
+    leaseSeconds: 3600,
+    secret: "Kslk30SNF2AChs2"
+}
+service websub:SubscriberService /subcriberMisMatchingAcceptHeader on websubSubscriberEPFour {
+    remote function onNotification(websub:Notification notification) {}
+}
+
+@websub:SubscriberServiceConfig {
+    subscribeOnStartUp: true,
+    target: "http://localhost:24080/publisherService/withAcceptLanguageHeader",
+    acceptLanguage: "de-DE",
+    leaseSeconds: 3600,
+    secret: "Kslk30SNF2AChs2"
+}
+service websub:SubscriberService /subcriberMatchingAcceptLanguageHeader on websubSubscriberEPFive {
+    remote function onNotification(websub:Notification notification) {}
+}
+
+@websub:SubscriberServiceConfig {
+    subscribeOnStartUp: true,
+    target: "http://localhost:24080/publisherService/withAcceptLanguageHeader",
+    acceptLanguage: "de-US",
+    leaseSeconds: 3600,
+    secret: "Kslk30SNF2AChs2"
+}
+service websub:SubscriberService /subcriberMisMatchingAcceptLanguageHeader on websubSubscriberEPSix {
+    remote function onNotification(websub:Notification notification) {}
+}
+
+@websub:SubscriberServiceConfig {
+    subscribeOnStartUp: true,
+    target: "http://localhost:24080/publisherService/withAcceptAndAcceptLanguageHeaders",
+    leaseSeconds: 3600,
+    secret: "Kslk30SNF2AChs2"
+}
+service websub:SubscriberService /subcriberMissingAcceptAndAcceptLanguageHeaders on websubSubscriberEPSeven {
+    remote function onNotification(websub:Notification notification) {}
+}
+
+@test:Config {}
+function testMatchingAcceptAndAcceptLanguageHeaderArray() {
+    test:assertEquals(fetchOutput(ID_MATCH_ACCEPT_AND_ACCEPT_LANGUAGE_HEADER_ARRAY), RESPONSE_CODE_ACCEPTED);
+}
+
+@test:Config {}
+function testMisMatchingAcceptAndAcceptLanguageHeaderArray() {
+    test:assertEquals(fetchOutput(ID_MISMATCH_ACCEPT_AND_ACCEPT_LANGUAGE_HEADER_ARRAY), RESPONSE_CODE_NOT_ACCEPTABLE);
+}
+
+@test:Config {}
+function testMatchingAcceptAndAcceptLanguageHeaders() {
+    test:assertEquals(fetchOutput(ID_MATCH_ACCEPT_AND_ACCEPT_LANGUAGE_HEADERS), RESPONSE_CODE_ACCEPTED);
+}
+
+@test:Config {}
+function testMisMatchingAcceptAndAcceptLanguageHeaders() {
+    test:assertEquals(fetchOutput(ID_MISMATCH_ACCEPT_AND_ACCEPT_LANGUAGE_HEADERS), RESPONSE_CODE_NOT_ACCEPTABLE);
+}
+
+@test:Config {}
+function testMatchingAcceptHeader() {
+    test:assertEquals(fetchOutput(ID_MATCH_ACCEPT_HEADER), RESPONSE_CODE_ACCEPTED);
+}
+
+@test:Config {}
+function testMisMatchingAcceptHeader() {
+    test:assertEquals(fetchOutput(ID_MISMATCH_ACCEPT_HEADER), RESPONSE_CODE_NOT_ACCEPTABLE);
+}
+
+@test:Config {}
+function testMatchingAcceptLanguageHeader() {
+    test:assertEquals(fetchOutput(ID_MATCH_ACCEPT_LANGUAGE_HEADER), RESPONSE_CODE_ACCEPTED);
+}
+
+@test:Config {}
+function testMisMatchingAcceptLanguageHeader() {
+    test:assertEquals(fetchOutput(ID_MISMATCH_ACCEPT_LANGUAGE_HEADER), RESPONSE_CODE_NOT_ACCEPTABLE);
+}
+
+@test:Config {}
+function testMissingAcceptAndAcceptLanguageHeaders() {
+    test:assertEquals(fetchOutput(ID_MISSING_ACCEPT_AND_ACCEPT_LANGUAGE_HEADERS), RESPONSE_CODE_INTERNAL_SERVER_ERROR);
+}

--- a/websub-native/src/main/java/org/ballerinalang/net/websub/WebSubSubscriberConstants.java
+++ b/websub-native/src/main/java/org/ballerinalang/net/websub/WebSubSubscriberConstants.java
@@ -58,6 +58,8 @@ public class WebSubSubscriberConstants {
 
     public static final BString ANN_WEBSUB_ATTR_SUBSCRIBE_ON_STARTUP = StringUtils.fromString("subscribeOnStartUp");
     public static final BString ANN_WEBSUB_ATTR_TARGET = StringUtils.fromString("target");
+    public static final BString ANN_WEBSUB_ATTR_ACCEPT = StringUtils.fromString("accept");
+    public static final BString ANN_WEBSUB_ATTR_ACCEPT_LANGUAGE = StringUtils.fromString("acceptLanguage");
     public static final BString ANN_WEBSUB_ATTR_LEASE_SECONDS = StringUtils.fromString("leaseSeconds");
     public static final BString ANN_WEBSUB_ATTR_SECRET = StringUtils.fromString("secret");
     public static final BString ANN_WEBSUB_ATTR_CALLBACK = StringUtils.fromString("callback");

--- a/websub-native/src/main/java/org/ballerinalang/net/websub/nativeimpl/SubscriberNativeOperationHandler.java
+++ b/websub-native/src/main/java/org/ballerinalang/net/websub/nativeimpl/SubscriberNativeOperationHandler.java
@@ -59,6 +59,8 @@ import static org.ballerinalang.net.websub.WebSubSubscriberConstants.ANN_WEBSUB_
 import static org.ballerinalang.net.websub.WebSubSubscriberConstants.ANN_WEBSUB_ATTR_SUBSCRIPTION_HUB_CLIENT_CONFIG;
 import static org.ballerinalang.net.websub.WebSubSubscriberConstants.ANN_WEBSUB_ATTR_SUBSCRIPTION_PUBLISHER_CLIENT_CONFIG;
 import static org.ballerinalang.net.websub.WebSubSubscriberConstants.ANN_WEBSUB_ATTR_TARGET;
+import static org.ballerinalang.net.websub.WebSubSubscriberConstants.ANN_WEBSUB_ATTR_ACCEPT;
+import static org.ballerinalang.net.websub.WebSubSubscriberConstants.ANN_WEBSUB_ATTR_ACCEPT_LANGUAGE;
 import static org.ballerinalang.net.websub.WebSubSubscriberConstants.ENDPOINT_CONFIG_HOST;
 import static org.ballerinalang.net.websub.WebSubSubscriberConstants.ENDPOINT_CONFIG_PORT;
 import static org.ballerinalang.net.websub.WebSubSubscriberConstants.ENDPOINT_CONFIG_SECURE_SOCKET_CONFIG;
@@ -335,6 +337,15 @@ public class SubscriberNativeOperationHandler {
 
             if (annotation.containsKey(ANN_WEBSUB_ATTR_TARGET)) {
                 subscriptionDetails.put(ANN_WEBSUB_ATTR_TARGET, annotation.get(ANN_WEBSUB_ATTR_TARGET));
+            }
+
+            if (annotation.containsKey(ANN_WEBSUB_ATTR_ACCEPT)) {
+                subscriptionDetails.put(ANN_WEBSUB_ATTR_ACCEPT, annotation.get(ANN_WEBSUB_ATTR_ACCEPT));
+            }
+
+            if (annotation.containsKey(ANN_WEBSUB_ATTR_ACCEPT_LANGUAGE)) {
+                subscriptionDetails.put(ANN_WEBSUB_ATTR_ACCEPT_LANGUAGE,
+                                        annotation.get(ANN_WEBSUB_ATTR_ACCEPT_LANGUAGE));
             }
 
             if (annotation.containsKey(ANN_WEBSUB_ATTR_LEASE_SECONDS)) {


### PR DESCRIPTION
## Purpose
Add accept and acceptLanguage fields to SubscriberServiceConfig annotation for content negotiation in the initial discovery request.

## Approach
Use annotation to retrieve accept and acceptLanguage fields.
Add retrieved values to initial discovery request.

## Samples
```ballerina
@websub:SubscriberServiceConfig {
    path: "/ordereventsubscriber",
    subscribeOnStartUp: true,
    target: "http://localhost:9091/ordermgt/order",
    accept:"application/json",
    acceptLanguage:"de-DE",
    leaseSeconds: 3600,
    secret: "Kslk30SNF2AChs2"
}
```