### PR TITLE
Add Codecov Report Generation

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -35,6 +35,8 @@ jobs:
           name: Ballerina Internal Log
           path: websubhub-ballerina/ballerina-internal.log
           if-no-files-found: ignore
+      - name: Generate Codecov Report
+        uses: codecov/codecov-action@v1
       - name: Archive Code Coverage JSON
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,7 +18,8 @@ jobs:
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew build --scan
-
+      - name: Generate Codecov Report
+        uses: codecov/codecov-action@v1
       - name: Archive Error Log
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,8 +18,6 @@ jobs:
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew build --scan
-      - name: Generate Codecov Report
-        uses: codecov/codecov-action@v1
       - name: Archive Error Log
         uses: actions/upload-artifact@v2
         if: failure()
@@ -27,6 +25,8 @@ jobs:
           name: Ballerina Internal Log
           path: websubhub-ballerina/ballerina-internal.log
           if-no-files-found: ignore
+      - name: Generate Codecov Report
+        uses: codecov/codecov-action@v1
       - name: Archive Code Coverage JSON
         uses: actions/upload-artifact@v2
         with:

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,4 +6,3 @@ fixes:
 
 ignore:
   - "**/tests"
-  

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,3 +6,4 @@ fixes:
 
 ignore:
   - "**/tests"
+  

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+codecov:
+  require_ci_to_pass: no
+
+fixes:
+  - "ballerina/websub/*/::websub-ballerina/"
+
+ignore:
+  - "**/tests"


### PR DESCRIPTION
## Purpose
> Introducing Codecov code coverage report publishing to the websub repository

## Goals
> Publishing the testerina generated code coverage xml to Codecov triggered via GitHub action of PR.

## Approach
>   A new job is inserted to Pull request and Build GitHub actions that publishes the XML report to Codecov.
    These jobs trigger on push or pull request and CodeCov generates a descriptive code coverage report.
    Codecov also adds comments to any PR made based on the code coverage changes between commits