### PR TITLE
Add mime support

### DIFF
--- a/websub-ballerina/commons.bal
+++ b/websub-ballerina/commons.bal
@@ -15,6 +15,7 @@
 // under the License.
 
 import ballerina/http;
+import ballerina/mime;
 
 # Intent verification request parameter 'hub.challenge' representing the challenge that needs to be echoed by
 # susbscribers to verify intent.
@@ -87,7 +88,7 @@ public type SubscriptionVerification record {
 public type ContentDistributionMessage record {
     map<string|string[]>? headers = ();
     string? contentType = ();
-    json|xml|string|byte[] content;
+    json|xml|string|byte[]|mime:Entity[] content;
 };
 
 # Record representing the common-response to be returned.

--- a/websub-ballerina/request_processor.bal
+++ b/websub-ballerina/request_processor.bal
@@ -16,6 +16,7 @@
 
 import ballerina/http;
 import ballerina/log;
+import ballerina/mime;
 
 # Porcesses the subscription / unsubscription intent verification requests from `hub`
 # 
@@ -82,21 +83,37 @@ isolated function processSubscriptionDenial(http:Caller caller, http:Response re
 isolated function processEventNotification(http:Caller caller, http:Request request, 
                                            http:Response response, SubscriberService subscriberService,
                                            string secretKey) {
-    var payload = request.getTextPayload();
-
     boolean isVerifiedContent = false;
-    if (payload is string) {
-        var verificationResponse = verifyContent(request, secretKey, payload);
-        
-        if (verificationResponse is boolean) {
-            isVerifiedContent = verificationResponse;
+    string payloadType = request.getContentType();
+
+    if (payloadType.includes("multipart")) {
+        var payload = request.getBodyParts();
+        if (payload is mime:Entity[]) {
+            var verificationResponse = verifyContent(request, secretKey, payload);  
+            if (verificationResponse is boolean) {
+                isVerifiedContent = verificationResponse;
+            } else {
+                response.statusCode = http:STATUS_INTERNAL_SERVER_ERROR;
+                return;
+            }
         } else {
             response.statusCode = http:STATUS_INTERNAL_SERVER_ERROR;
             return;
         }
     } else {
-        response.statusCode = http:STATUS_INTERNAL_SERVER_ERROR;
-        return;
+        var payload = request.getTextPayload();
+        if (payload is string) {
+            var verificationResponse = verifyContent(request, secretKey, payload);
+            if (verificationResponse is boolean) {
+                isVerifiedContent = verificationResponse;
+            } else {
+                response.statusCode = http:STATUS_INTERNAL_SERVER_ERROR;
+                return;
+            }
+        } else {
+            response.statusCode = http:STATUS_INTERNAL_SERVER_ERROR;
+            return;
+        }
     }
 
     if (!isVerifiedContent) {
@@ -104,6 +121,10 @@ isolated function processEventNotification(http:Caller caller, http:Request requ
     }
                                                
     string contentType = request.getContentType();
+    if (contentType.includes("multipart")) {
+        contentType = "multipart";
+    }
+
     map<string|string[]> headers = retrieveRequestHeaders(request);
     ContentDistributionMessage? message = ();
 
@@ -134,6 +155,13 @@ isolated function processEventNotification(http:Caller caller, http:Request requ
                 headers: headers,
                 contentType: "application/octet-stream",
                 content: checkpanic request.getBinaryPayload()
+            };  
+        }
+        "multipart" => {
+            message = {
+                headers: headers,
+                contentType: request.getContentType(),
+                content: checkpanic request.getBodyParts()
             };  
         }
         _ => {

--- a/websub-ballerina/utils.bal
+++ b/websub-ballerina/utils.bal
@@ -19,6 +19,7 @@ import ballerina/regex;
 import ballerina/crypto;
 import ballerina/log;
 import ballerina/lang.'string as strings;
+import ballerina/mime;
 
 # Retrieves the `websub:SubscriberServiceConfig` annotation values
 # 
@@ -157,7 +158,7 @@ isolated function retrieveRequestQueryParams(http:Request request) returns Reque
 # + secret - pre-shared client-secret value
 # + payload - {@code string} value of the request body
 # + return - `true` if the verification is successfull, else `false`
-isolated function verifyContent(http:Request request, string secret, string payload) returns boolean|error {
+isolated function verifyContent(http:Request request, string secret, string|mime:Entity[] payload) returns boolean|error {
     if (secret.trim().length() > 0) {
         if (request.hasHeader(X_HUB_SIGNATURE)) {
                 var xHubSignature = request.getHeader(X_HUB_SIGNATURE);
@@ -187,10 +188,21 @@ isolated function verifyContent(http:Request request, string secret, string payl
 # + key - pre-shared secret-key value
 # + payload - content to be hashed
 # + return - {@code byte[]} representing the `hMac`
-isolated function retrieveContentHash(string method, string key, string payload) returns byte[]|error {
+isolated function retrieveContentHash(string method, string key, string|mime:Entity[] payload) returns byte[]|error {
     byte[] keyArr = key.toBytes();
-    byte[] contentPayload = payload.toBytes();
+    byte[] contentPayload = [];
     byte[] hashedContent = [];
+
+    if (payload is mime:Entity[]) {
+        foreach mime:Entity entity in payload {
+            byte[] inputArr = entity.toString().toBytes();
+            foreach byte ele in inputArr {
+                contentPayload.push(ele);
+            }
+        }
+    } else {
+        contentPayload = payload.toBytes();
+    }
 
     match method {
         "sha1" => {


### PR DESCRIPTION
## Purpose

For supporting mime content delivery for websub.

## Approach

Add mime:Entity type for contentDistributionMessage record
Add mime:Entity array comes from websubhub into contentDistributionMessage which is delivered to subscriber.


## Samples
```
public type ContentDistributionMessage record {
    map<string|string[]>? headers = ();
    string? contentType = ();
    json|xml|string|byte[]|mime:Entity[] content;
};
```
