### PR TITLE
Mime support

### DIFF
--- a/websub-ballerina/commons.bal
+++ b/websub-ballerina/commons.bal
@@ -15,6 +15,7 @@
 // under the License.
 
 import ballerina/http;
+import ballerina/mime;
 
 # Intent verification request parameter 'hub.challenge' representing the challenge that needs to be echoed by
 # susbscribers to verify intent.
@@ -93,7 +94,7 @@ public type SubscriptionVerification record {
 public type ContentDistributionMessage record {
     map<string|string[]>? headers = ();
     string? contentType = ();
-    json|xml|string|byte[] content;
+    json|xml|string|byte[]|mime:Entity[] content;
 };
 
 # Record representing the common-response to be returned.

--- a/websub-ballerina/request_processor.bal
+++ b/websub-ballerina/request_processor.bal
@@ -16,6 +16,7 @@
 
 import ballerina/http;
 import ballerina/log;
+import ballerina/mime;
 
 # Porcesses the subscription / unsubscription intent verification requests from `hub`
 # 
@@ -82,21 +83,37 @@ isolated function processSubscriptionDenial(http:Caller caller, http:Response re
 isolated function processEventNotification(http:Caller caller, http:Request request, 
                                            http:Response response, SubscriberService subscriberService,
                                            string secretKey) {
-    var payload = request.getTextPayload();
-
     boolean isVerifiedContent = false;
-    if (payload is string) {
-        var verificationResponse = verifyContent(request, secretKey, payload);
-        
-        if (verificationResponse is boolean) {
-            isVerifiedContent = verificationResponse;
+    var payloadType = request.getContentType();
+
+    if (payloadType.includes("multipart")) {
+        var payload = request.getBodyParts();
+        if (payload is mime:Entity[]) {
+            var verificationResponse = verifyContent(request, secretKey, payload);      
+            if (verificationResponse is boolean) {
+                isVerifiedContent = verificationResponse;
+            } else {
+                response.statusCode = http:STATUS_INTERNAL_SERVER_ERROR;
+                return;
+            }
         } else {
             response.statusCode = http:STATUS_INTERNAL_SERVER_ERROR;
             return;
         }
     } else {
-        response.statusCode = http:STATUS_INTERNAL_SERVER_ERROR;
-        return;
+        var payload = request.getTextPayload();
+        if (payload is string) {
+            var verificationResponse = verifyContent(request, secretKey, payload);
+            if (verificationResponse is boolean) {
+                isVerifiedContent = verificationResponse;
+            } else {
+                response.statusCode = http:STATUS_INTERNAL_SERVER_ERROR;
+                return;
+            }
+        } else {
+            response.statusCode = http:STATUS_INTERNAL_SERVER_ERROR;
+            return;
+        }
     }
 
     if (!isVerifiedContent) {
@@ -104,6 +121,10 @@ isolated function processEventNotification(http:Caller caller, http:Request requ
     }
                                                
     string contentType = request.getContentType();
+    if (contentType.includes("multipart")) {
+        contentType = "multipart";
+    }
+
     map<string|string[]> headers = retrieveRequestHeaders(request);
     ContentDistributionMessage? message = ();
 
@@ -134,6 +155,13 @@ isolated function processEventNotification(http:Caller caller, http:Request requ
                 headers: headers,
                 contentType: "application/octet-stream",
                 content: checkpanic request.getBinaryPayload()
+            };  
+        }
+        "multipart" => {
+            message = {
+                headers: headers,
+                contentType: request.getContentType(),
+                content: checkpanic request.getBodyParts()
             };  
         }
         _ => {

--- a/websub-ballerina/tests/additional_external_error_data_test.bal
+++ b/websub-ballerina/tests/additional_external_error_data_test.bal
@@ -16,6 +16,7 @@
 
 import ballerina/log;
 import ballerina/http;
+import ballerina/io;
 import ballerina/regex;   
 import ballerina/test;
 
@@ -39,7 +40,8 @@ var serviceWithAdditionalErrorDetails = @SubscriberServiceConfig { target: "http
 
     remote function onEventNotification(ContentDistributionMessage event) 
                         returns Acknowledgement | SubscriptionDeletedError? {
-        log:printDebug("onEventNotification invoked: ", contentDistributionNotification = event);
+        //log:printDebug("onEventNotification invoked: ", contentDistributionNotification = event);
+        io:println("onEventNotification invoked: ", event);
         return error SubscriptionDeletedError(
             "Subscriber wants to unsubscribe",
             headers = {"header1": "value"}, 

--- a/websub-ballerina/tests/basic_subscriber_test.bal
+++ b/websub-ballerina/tests/basic_subscriber_test.bal
@@ -131,7 +131,7 @@ function testOnEventNotificationSuccessMime() returns @tainted error? {
     http:Request request = new;
     mime:Entity jsonBodyPart = new;
     jsonBodyPart.setContentDisposition(getContentDispositionForFormData("json part"));
-    jsonBodyPart.setJson({"name": "ballerina"});
+    jsonBodyPart.setJson({"name": "wso2"});
 
     mime:Entity textBodyPart = new;
     textBodyPart.setContentDisposition(getContentDispositionForFormData("text part"));

--- a/websub-ballerina/tests/basic_subscriber_test.bal
+++ b/websub-ballerina/tests/basic_subscriber_test.bal
@@ -131,7 +131,7 @@ function testOnEventNotificationSuccessMime() returns @tainted error? {
     http:Request request = new;
     mime:Entity jsonBodyPart = new;
     jsonBodyPart.setContentDisposition(getContentDispositionForFormData("json part"));
-    jsonBodyPart.setJson({"name": "wso2"});
+    jsonBodyPart.setJson({"name": "ballerina"});
 
     mime:Entity textBodyPart = new;
     textBodyPart.setContentDisposition(getContentDispositionForFormData("text part"));

--- a/websub-ballerina/tests/basic_subscriber_test.bal
+++ b/websub-ballerina/tests/basic_subscriber_test.bal
@@ -17,6 +17,8 @@
 import ballerina/log;
 import ballerina/test;
 import ballerina/http;
+import ballerina/io;
+import ballerina/mime;
 
 listener Listener basicSubscriberListener = new (9090);
 
@@ -43,10 +45,19 @@ var simpleSubscriberService = @SubscriberServiceConfig { target: "http://0.0.0.0
 
     remote function onEventNotification(ContentDistributionMessage event) 
                         returns Acknowledgement | SubscriptionDeletedError? {
-        log:printDebug("onEventNotification invoked ", contentDistributionMessage = event);
+        //log:printDebug("onEventNotification invoked ", contentDistributionMessage = event);
+        io:println("onEventNotification invoked ", event);
         return {};
     }
 };
+
+isolated function getContentDispositionForFormData(string partName)
+                                    returns (mime:ContentDisposition) {
+    mime:ContentDisposition contentDisposition = new;
+    contentDisposition.name = partName;
+    contentDisposition.disposition = "form-data";
+    return contentDisposition;
+}
 
 @test:BeforeGroups { value:["simple-subscriber"] }
 function beforeSimpleSubscriberTest() {
@@ -107,6 +118,26 @@ function testOnEventNotificationSuccess() returns @tainted error? {
 function testOnEventNotificationSuccessXml() returns @tainted error? {
     http:Request request = new;
     xml payload = xml `<body><action>publish</action></body>`;
+    request.setPayload(payload);
+
+    http:Response response = check httpClient->post("/", request);
+    test:assertEquals(response.statusCode, 202);
+}
+
+@test:Config {
+    groups: ["simple-subscriber"]
+}
+function testOnEventNotificationSuccessMime() returns @tainted error? {
+    http:Request request = new;
+    mime:Entity jsonBodyPart = new;
+    jsonBodyPart.setContentDisposition(getContentDispositionForFormData("json part"));
+    jsonBodyPart.setJson({"name": "wso2"});
+
+    mime:Entity textBodyPart = new;
+    textBodyPart.setContentDisposition(getContentDispositionForFormData("text part"));
+    textBodyPart.setText("Sample text");
+
+    mime:Entity[] payload = [jsonBodyPart, textBodyPart];
     request.setPayload(payload);
 
     http:Response response = check httpClient->post("/", request);

--- a/websub-ballerina/tests/default_method_impl_test.bal
+++ b/websub-ballerina/tests/default_method_impl_test.bal
@@ -14,9 +14,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/log;
 import ballerina/test;
 import ballerina/http;
+import ballerina/io;
 
 listener Listener serviceWithDefaultImplListener = new (9091);
 
@@ -24,7 +24,8 @@ var serviceWithDefaultImpl = @SubscriberServiceConfig { target: "http://0.0.0.0:
                               service object {
     remote function onEventNotification(ContentDistributionMessage event) 
                         returns Acknowledgement | SubscriptionDeletedError? {
-        log:printDebug("onEventNotification invoked ", contentDistributionMessage = event);
+        //log:printDebug("onEventNotification invoked ", contentDistributionMessage = event);
+        io:println("onEventNotification invoked ", event);
         return {};
     }
 };

--- a/websub-ballerina/tests/multi_service_listener_test.bal
+++ b/websub-ballerina/tests/multi_service_listener_test.bal
@@ -18,6 +18,7 @@ import ballerina/log;
 import ballerina/test;
 import ballerina/http;
 import ballerina/io;
+import ballerina/mime;
 
 listener Listener multiServiceListener = new(9096);
 
@@ -162,6 +163,46 @@ function testOnEventNotificationSuccessXmlServiceOne() returns @tainted error? {
 function testOnEventNotificationSuccessXmlServiceTwo() returns @tainted error? {
     http:Request request = new;
     xml payload = xml `<body><action>publish</action></body>`;
+    request.setPayload(payload);
+
+    http:Response response = check clientForServiceTwo->post("/", request);
+    test:assertEquals(response.statusCode, 202);
+}
+
+@test:Config {
+    groups: ["multiServiceListener"]
+}
+function testOnEventNotificationSuccessMimeServiceOne() returns @tainted error? {
+    http:Request request = new;
+    mime:Entity jsonBodyPart = new;
+    jsonBodyPart.setContentDisposition(getContentDispositionForFormData("json part"));
+    jsonBodyPart.setJson({"name": "ballerina"});
+
+    mime:Entity textBodyPart = new;
+    textBodyPart.setContentDisposition(getContentDispositionForFormData("text part"));
+    textBodyPart.setText("Sample text");
+
+    mime:Entity[] payload = [jsonBodyPart, textBodyPart];
+    request.setPayload(payload);
+
+    http:Response response = check clientForServiceOne->post("/", request);
+    test:assertEquals(response.statusCode, 202);
+}
+
+@test:Config {
+    groups: ["multiServiceListener"]
+}
+function testOnEventNotificationSuccessMimeServiceTwo() returns @tainted error? {
+    http:Request request = new;
+    mime:Entity jsonBodyPart = new;
+    jsonBodyPart.setContentDisposition(getContentDispositionForFormData("json part"));
+    jsonBodyPart.setJson({"name": "ballerina"});
+
+    mime:Entity textBodyPart = new;
+    textBodyPart.setContentDisposition(getContentDispositionForFormData("text part"));
+    textBodyPart.setText("Sample text");
+
+    mime:Entity[] payload = [jsonBodyPart, textBodyPart];
     request.setPayload(payload);
 
     http:Response response = check clientForServiceTwo->post("/", request);

--- a/websub-ballerina/tests/multi_service_listener_test.bal
+++ b/websub-ballerina/tests/multi_service_listener_test.bal
@@ -17,6 +17,7 @@
 import ballerina/log;
 import ballerina/test;
 import ballerina/http;
+import ballerina/io;
 
 listener Listener multiServiceListener = new(9096);
 
@@ -43,7 +44,8 @@ service /subscriberOne on multiServiceListener {
 
     remote function onEventNotification(ContentDistributionMessage event) 
                         returns Acknowledgement|SubscriptionDeletedError? {
-        log:printDebug("onEventNotification invoked ", contentDistributionMessage = event);
+        //log:printDebug("onEventNotification invoked ", contentDistributionMessage = event);
+        io:println("onEventNotification invoked ", event);
         return {};
     }
 }
@@ -71,7 +73,8 @@ service /subscriberTwo on multiServiceListener {
 
     remote function onEventNotification(ContentDistributionMessage event) 
                         returns Acknowledgement|SubscriptionDeletedError? {
-        log:printDebug("onEventNotification invoked ", contentDistributionMessage = event);
+        //log:printDebug("onEventNotification invoked ", contentDistributionMessage = event);
+        io:println("onEventNotification invoked ", event);
         return {};
     }
 }

--- a/websub-ballerina/tests/optional_subscriber_target_test.bal
+++ b/websub-ballerina/tests/optional_subscriber_target_test.bal
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/log;
+import ballerina/io;
 import ballerina/test;
 
 listener Listener optionalTargetListener = new (9094);
@@ -23,7 +23,8 @@ var optionalSubscriberTarget = @SubscriberServiceConfig { leaseSeconds: 36000, s
                               service object {
     remote function onEventNotification(ContentDistributionMessage event) 
                         returns Acknowledgement | SubscriptionDeletedError? {
-        log:printDebug("onEventNotification invoked ", contentDistributionMessage = event);
+        //log:printDebug("onEventNotification invoked ", contentDistributionMessage = event);
+        io:println("onEventNotification invoked ", event);
         return {};
     }
 };

--- a/websub-ballerina/tests/service_path_generation_test.bal
+++ b/websub-ballerina/tests/service_path_generation_test.bal
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/log;
+import ballerina/io;
 import ballerina/test;
 
 listener Listener pathGenerationListener = new (9092);
@@ -23,7 +23,8 @@ var serviceWithPathGeneration = @SubscriberServiceConfig { target: "http://0.0.0
                               service object {
     remote function onEventNotification(ContentDistributionMessage event) 
                         returns Acknowledgement | SubscriptionDeletedError? {
-        log:printDebug("onEventNotification invoked ", contentDistributionMessage = event);
+        //log:printDebug("onEventNotification invoked ", contentDistributionMessage = event);
+        io:println("onEventNotification invoked ", event);
         return {};
     }
 };

--- a/websub-ballerina/tests/ssl_enabled_subscriber_test.bal
+++ b/websub-ballerina/tests/ssl_enabled_subscriber_test.bal
@@ -18,6 +18,7 @@ import ballerina/log;
 import ballerina/test;
 import ballerina/http;
 import ballerina/io;
+import ballerina/mime;
 
 ListenerConfiguration listenerConfigs = {
     secureSocket: {
@@ -116,6 +117,26 @@ function testOnEventNotificationSuccessWithSsl() returns @tainted error? {
 function testOnEventNotificationSuccessXmlWithSsl() returns @tainted error? {
     http:Request request = new;
     xml payload = xml `<body><action>publish</action></body>`;
+    request.setPayload(payload);
+
+    http:Response response = check sslEnabledClient->post("/", request);
+    test:assertEquals(response.statusCode, 202);
+}
+
+@test:Config {
+    groups: ["sslEnabledSubscriber"]
+}
+function testOnEventNotificationSuccessMimeWithSsl() returns @tainted error? {
+    http:Request request = new;
+    mime:Entity jsonBodyPart = new;
+    jsonBodyPart.setContentDisposition(getContentDispositionForFormData("json part"));
+    jsonBodyPart.setJson({"name": "ballerina"});
+
+    mime:Entity textBodyPart = new;
+    textBodyPart.setContentDisposition(getContentDispositionForFormData("text part"));
+    textBodyPart.setText("Sample text");
+
+    mime:Entity[] payload = [jsonBodyPart, textBodyPart];
     request.setPayload(payload);
 
     http:Response response = check sslEnabledClient->post("/", request);

--- a/websub-ballerina/tests/ssl_enabled_subscriber_test.bal
+++ b/websub-ballerina/tests/ssl_enabled_subscriber_test.bal
@@ -17,6 +17,7 @@
 import ballerina/log;
 import ballerina/test;
 import ballerina/http;
+import ballerina/io;
 
 ListenerConfiguration listenerConfigs = {
     secureSocket: {
@@ -52,7 +53,8 @@ service /subscriber on sslEnabledListener {
 
     remote function onEventNotification(ContentDistributionMessage event) 
                         returns Acknowledgement|SubscriptionDeletedError? {
-        log:printDebug("onEventNotification invoked ", contentDistributionMessage = event);
+        //log:printDebug("onEventNotification invoked ", contentDistributionMessage = event);
+        io:println("onEventNotification invoked ", event);
         return {};
     }
 }

--- a/websub-ballerina/tests/websub_config_manual_attach_test.bal
+++ b/websub-ballerina/tests/websub_config_manual_attach_test.bal
@@ -17,6 +17,7 @@
 import ballerina/log;
 import ballerina/test;
 import ballerina/http;
+import ballerina/io;
 
 service class SimpleWebsubService {
     *SubscriberService;
@@ -41,7 +42,8 @@ service class SimpleWebsubService {
 
     remote function onEventNotification(ContentDistributionMessage event) 
                         returns Acknowledgement | SubscriptionDeletedError? {
-        log:printDebug("onEventNotification invoked ", contentDistributionMessage = event);
+        //log:printDebug("onEventNotification invoked ", contentDistributionMessage = event);
+        io:println("onEventNotification invoked ", event);
         return {};
     }
 }

--- a/websub-ballerina/utils.bal
+++ b/websub-ballerina/utils.bal
@@ -19,6 +19,7 @@ import ballerina/regex;
 import ballerina/crypto;
 import ballerina/log;
 import ballerina/lang.'string as strings;
+import ballerina/mime;
 
 # Retrieves the `websub:SubscriberServiceConfig` annotation values
 # 
@@ -157,7 +158,7 @@ isolated function retrieveRequestQueryParams(http:Request request) returns Reque
 # + secret - pre-shared client-secret value
 # + payload - {@code string} value of the request body
 # + return - `true` if the verification is successfull, else `false`
-isolated function verifyContent(http:Request request, string secret, string payload) returns boolean|error {
+isolated function verifyContent(http:Request request, string secret, string|mime:Entity[] payload) returns boolean|error {
     if (secret.trim().length() > 0) {
         if (request.hasHeader(X_HUB_SIGNATURE)) {
                 var xHubSignature = request.getHeader(X_HUB_SIGNATURE);
@@ -187,10 +188,21 @@ isolated function verifyContent(http:Request request, string secret, string payl
 # + key - pre-shared secret-key value
 # + payload - content to be hashed
 # + return - {@code byte[]} representing the `hMac`
-isolated function retrieveContentHash(string method, string key, string payload) returns byte[]|error {
+isolated function retrieveContentHash(string method, string key, string|mime:Entity[] payload) returns byte[]|error {
     byte[] keyArr = key.toBytes();
-    byte[] contentPayload = payload.toBytes();
+    byte[] contentPayload = [];
     byte[] hashedContent = [];
+    
+    if (payload is mime:Entity[]) {
+        foreach mime:Entity entity in payload {
+            byte[] inputArr = entity.toString().toBytes();
+            foreach byte ele in inputArr {
+                contentPayload.push(ele);
+            }
+        }
+    } else {
+        contentPayload = payload.toBytes();
+    }
 
     match method {
         SHA1 => {


### PR DESCRIPTION
## Purpose
Support mime content delivery for websub


## Approach
Add mime:Entity[] type to `ContentDistributionMessage` record
extract mime content from publisher's payload and set to `ContentDistributionMessage` 

## Samples
```
public type ContentDistributionMessage record {
    map<string|string[]>? headers = ();
    string? contentType = ();
    json|xml|string|byte[]|mime:Entity[] content;
}; 
```

