### PR TITLE
Fix issue in url-encoded content retrieval

### DIFF
--- a/websub-ballerina/commons.bal
+++ b/websub-ballerina/commons.bal
@@ -93,7 +93,7 @@ public type SubscriptionVerification record {
 public type ContentDistributionMessage record {
     map<string|string[]>? headers = ();
     string? contentType = ();
-    map<string>|json|xml|string|byte[] content;
+    map<string|string[]>|json|xml|string|byte[] content;
 };
 
 # Record representing the common-response to be returned.

--- a/websub-ballerina/commons.bal
+++ b/websub-ballerina/commons.bal
@@ -93,7 +93,7 @@ public type SubscriptionVerification record {
 public type ContentDistributionMessage record {
     map<string|string[]>? headers = ();
     string? contentType = ();
-    map<string[]>|json|xml|string|byte[] content;
+    map<string>|json|xml|string|byte[] content;
 };
 
 # Record representing the common-response to be returned.

--- a/websub-ballerina/request_processor.bal
+++ b/websub-ballerina/request_processor.bal
@@ -17,6 +17,7 @@
 import ballerina/http;
 import ballerina/mime;
 import ballerina/log;
+import ballerina/url;
 
 # Porcesses the subscription / unsubscription intent verification requests from `hub`
 # 
@@ -113,10 +114,15 @@ isolated function processEventNotification(http:Caller caller, http:Request requ
             };  
         }
         mime:APPLICATION_FORM_URLENCODED => {
+            map<string> formContent = check request.getFormParams();
+            map<string> decodedContent = {};
+            foreach var ['key, value] in formContent.entries() {
+                decodedContent['key] = check url:decode(value, "UTF-8");
+            }
             message = {
                 headers: headers,
                 contentType: contentType,
-                content: request.getQueryParams()
+                content: decodedContent
             }; 
         }
         _ => {

--- a/websub-ballerina/request_processor.bal
+++ b/websub-ballerina/request_processor.bal
@@ -74,7 +74,7 @@ isolated function processSubscriptionDenial(http:Caller caller, http:Response re
 isolated function processEventNotification(http:Caller caller, http:Request request, 
                                            http:Response response, SubscriberService subscriberService,
                                            string secretKey) returns error? {
-    string payload = check retrieveTextPayload(request);
+    string payload = check request.getTextPayload();
     boolean isVerifiedContent = check verifyContent(request, secretKey, payload);
     if (!isVerifiedContent) {
         return;

--- a/websub-ballerina/tests/basic_subscriber_test.bal
+++ b/websub-ballerina/tests/basic_subscriber_test.bal
@@ -42,7 +42,7 @@ var simpleSubscriberService = @SubscriberServiceConfig { target: "http://0.0.0.0
                         returns Acknowledgement|SubscriptionDeletedError? {
         match event.contentType {
             mime:APPLICATION_FORM_URLENCODED => {
-                map<string[]> content = <map<string[]>> event.content;
+                map<string> content = <map<string>> event.content;
                 log:printInfo("URL encoded content received ", content = content);
             }
             _ => {
@@ -114,7 +114,6 @@ function testOnEventNotificationSuccessXml() returns @tainted error? {
     http:Request request = new;
     xml payload = xml `<body><action>publish</action></body>`;
     request.setPayload(payload);
-
     http:Response response = check httpClient->post("/", request);
     test:assertEquals(response.statusCode, 202);
 }
@@ -124,7 +123,8 @@ function testOnEventNotificationSuccessXml() returns @tainted error? {
 }
 function testOnEventNotificationSuccessForUrlEncoded() returns @tainted error? {
     http:Request request = new;
+    request.setTextPayload("param1=value1&param2=value2");
     check request.setContentType(mime:APPLICATION_FORM_URLENCODED);
-    http:Response response = check httpClient->post("/?param1=value1&param2=value2", request);
+    http:Response response = check httpClient->post("", request);
     test:assertEquals(response.statusCode, 202);
 }

--- a/websub-ballerina/tests/content_verification_test.bal
+++ b/websub-ballerina/tests/content_verification_test.bal
@@ -31,7 +31,7 @@ boolean xmlContentVerified = false;
 service /subscriber on new Listener(9098) {
     remote function onEventNotification(ContentDistributionMessage event) 
                         returns Acknowledgement|SubscriptionDeletedError? {
-        log:printInfo("onEventNotification invoked ", contentDistributionMessage = event);
+        log:printInfo("[VERIFICATION] onEventNotification invoked ", contentDistributionMessage = event);
         match event.contentType {
             mime:APPLICATION_FORM_URLENCODED => {
                 urlEncodedContentVerified = true;
@@ -87,9 +87,10 @@ function testOnEventNotificationSuccessForUrlEncodedForContentVerification() ret
     http:Request request = new;
     string payload = "param1=value1&param2=value2";
     byte[] payloadHash = check retrievePayloadSignature(hashKey, payload);
+    request.setTextPayload(payload);
     request.setHeader("X-Hub-Signature", string`sha256=${payloadHash.toBase16()}`);
     check request.setContentType(mime:APPLICATION_FORM_URLENCODED);
-    http:Response response = check contentVerificationClient->post(string`/?${payload}`, request);
+    http:Response response = check contentVerificationClient->post("", request);
     test:assertEquals(response.statusCode, 202);
     test:assertTrue(urlEncodedContentVerified);
 }

--- a/websub-ballerina/tests/content_verification_test.bal
+++ b/websub-ballerina/tests/content_verification_test.bal
@@ -100,16 +100,16 @@ isolated function retrievePayloadSignature(string 'key, string|xml|json|byte[] p
     if (payload is byte[]) {
         return crypto:hmacSha256(payload, keyArr);
     } else if (payload is string) {
-        byte[] inputArr = (<string>payload).toBytes();
+        byte[] inputArr = payload.toBytes();
         return crypto:hmacSha256(inputArr, keyArr);
     } else if (payload is xml) {
-        byte[] inputArr = (<xml>payload).toString().toBytes();
+        byte[] inputArr = payload.toString().toBytes();
         return crypto:hmacSha256(inputArr, keyArr);   
     } else if (payload is map<string>) {
-        byte[] inputArr = (<map<string>>payload).toString().toBytes();
+        byte[] inputArr = payload.toString().toBytes();
         return crypto:hmacSha256(inputArr, keyArr); 
     } else {
-        byte[] inputArr = (<json>payload).toJsonString().toBytes();
+        byte[] inputArr = payload.toJsonString().toBytes();
         return crypto:hmacSha256(inputArr, keyArr);
     }
 }

--- a/websub-ballerina/tests/multi_service_listener_test.bal
+++ b/websub-ballerina/tests/multi_service_listener_test.bal
@@ -163,8 +163,9 @@ function testOnEventNotificationSuccessXmlServiceTwo() returns @tainted error? {
 }
 function testOnEventNotificationSuccessForUrlEncodedServiceOne() returns @tainted error? {
     http:Request request = new;
+    request.setTextPayload("param1=value1&param2=value2");
     check request.setContentType(mime:APPLICATION_FORM_URLENCODED);
-    http:Response response = check clientForServiceOne->post("/?param1=value1&param2=value2", request);
+    http:Response response = check clientForServiceOne->post("", request);
     test:assertEquals(response.statusCode, 202);
 }
 
@@ -173,7 +174,8 @@ function testOnEventNotificationSuccessForUrlEncodedServiceOne() returns @tainte
 }
 function testOnEventNotificationSuccessForUrlEncodedServiceTwo() returns @tainted error? {
     http:Request request = new;
+    request.setTextPayload("param1=value1&param2=value2");
     check request.setContentType(mime:APPLICATION_FORM_URLENCODED);
-    http:Response response = check clientForServiceTwo->post("/?param1=value1&param2=value2", request);
+    http:Response response = check clientForServiceTwo->post("", request);
     test:assertEquals(response.statusCode, 202);
 }

--- a/websub-ballerina/tests/ssl_enabled_subscriber_test.bal
+++ b/websub-ballerina/tests/ssl_enabled_subscriber_test.bal
@@ -122,7 +122,8 @@ function testOnEventNotificationSuccessXmlWithSsl() returns @tainted error? {
 }
 function testOnEventNotificationSuccessForUrlEncodedWithSsl() returns @tainted error? {
     http:Request request = new;
+    request.setTextPayload("param1=value1&param2=value2");
     check request.setContentType(mime:APPLICATION_FORM_URLENCODED);
-    http:Response response = check sslEnabledClient->post("/?param1=value1&param2=value2", request);
+    http:Response response = check sslEnabledClient->post("", request);
     test:assertEquals(response.statusCode, 202);
 }

--- a/websub-ballerina/tests/websub_config_manual_attach_test.bal
+++ b/websub-ballerina/tests/websub_config_manual_attach_test.bal
@@ -118,7 +118,8 @@ function testOnEventNotificationSuccessXmlWithManualConfigAttach() returns @tain
 }
 function testOnEventNotificationSuccessForUrlEncodedWithManualConfigAttach() returns @tainted error? {
     http:Request request = new;
+    request.setTextPayload("param1=value1&param2=value2");
     check request.setContentType(mime:APPLICATION_FORM_URLENCODED);
-    http:Response response = check manualConfigAttachClientEp->post("/?param1=value1&param2=value2", request);
+    http:Response response = check manualConfigAttachClientEp->post("", request);
     test:assertEquals(response.statusCode, 202);
 }

--- a/websub-ballerina/utils.bal
+++ b/websub-ballerina/utils.bal
@@ -20,8 +20,6 @@ import ballerina/crypto;
 import ballerina/log;
 import ballerina/lang.'string as strings;
 import ballerina/random;
-import ballerina/mime;
-import ballerina/url;
 
 # Generates a random-string of given length
 # 
@@ -115,23 +113,6 @@ isolated function retrieveRequestQueryParams(http:Request request) returns Reque
         }
     } else {
         return {};
-    }
-}
-
-# Retrieves request payload for content-verification
-# 
-# + request - original {@code http:Request} object
-# + return - {@code string} containg the text-representation of the payload or {@code error}
-isolated function retrieveTextPayload(http:Request request) returns string|error {
-    string contentType = request.getContentType();
-    string rawPayload = check request.getTextPayload();
-    match request.getContentType() {
-        mime:APPLICATION_FORM_URLENCODED => {
-            return check url:decode(rawPayload, "UTF-8");
-        }
-        _ => {
-            return rawPayload;
-        }
     }
 }
 

--- a/websub-ballerina/utils.bal
+++ b/websub-ballerina/utils.bal
@@ -21,6 +21,7 @@ import ballerina/log;
 import ballerina/lang.'string as strings;
 import ballerina/random;
 import ballerina/mime;
+import ballerina/url;
 
 # Generates a random-string of given length
 # 
@@ -123,18 +124,13 @@ isolated function retrieveRequestQueryParams(http:Request request) returns Reque
 # + return - {@code string} containg the text-representation of the payload or {@code error}
 isolated function retrieveTextPayload(http:Request request) returns string|error {
     string contentType = request.getContentType();
+    string rawPayload = check request.getTextPayload();
     match request.getContentType() {
         mime:APPLICATION_FORM_URLENCODED => {
-            string[] queryParams = [];
-            foreach var ['key, values] in request.getQueryParams().entries() {
-                string concatenatedValue = strings:'join(",", ...values);
-                string query = string`${'key}=${concatenatedValue}`;
-                queryParams.push(query);
-            }
-            return strings:'join("&", ...queryParams);
+            return check url:decode(rawPayload, "UTF-8");
         }
         _ => {
-            return check request.getTextPayload();
+            return rawPayload;
         }
     }
 }


### PR DESCRIPTION
## Purpose
> $subject

## Samples
> Updated `x-form-urlencoded` support for content distribution.
```ballerina
    @websub:SubscriberServiceConfig {
        target: ["https://sample.hub", "https://sample.topic.two"], 
        leaseSeconds: 36000,
        secret: "secretKey"
    } 
    service /subscriber on new websub:Listener(9090) {
        remote function onEventNotification(websub:ContentDistributionMessage event) 
                        returns websub:Acknowledgement|websub:SubscriptionDeletedError? {
            match event.contentType {
            	mime:APPLICATION_FORM_URLENCODED => {
            		map<string|string[]> content = <map<string|string[]>> event.content;
            		// implement the event notification logic for x-form-urlencoded content
            	}
            	_ => {
            		// implement the event notification logic for other content types
            	}
            }
            return websub:ACKNOWLEDGEMENT;
        }
    }
```

## Related PRs
> #159 

Fixes: [#1106](https://github.com/ballerina-platform/ballerina-standard-library/issues/1106)