### PR TITLE
Revert "Sync with HTTP inbound error response update"

### DIFF
--- a/websub-ballerina/resource_discovery.bal
+++ b/websub-ballerina/resource_discovery.bal
@@ -87,14 +87,8 @@ public client class DiscoveryService {
                 return topicAndHubs;
             }
         } else {
-            string message = "";
-            if (discoveryResponse is http:ApplicationResponseError) {
-                message = <string> discoveryResponse.detail().body;
-            } else {
-                message = discoveryResponse.message();
-            }            
             return error ResourceDiscoveryFailedError("Error occurred with WebSub discovery for Resource URL [" + self.resourceUrl + "]: " +
-                            message);
+                            (<error>discoveryResponse).message());
         }                                       
     }
 }
@@ -112,6 +106,10 @@ isolated function extractTopicAndHubUrls(http:Response response) returns @tainte
         linkHeaders = check response.getHeaders("Link");
     }
     
+    if response.statusCode == http:STATUS_NOT_ACCEPTABLE {
+        return error ResourceDiscoveryFailedError("Content negotiation failed.Accept and/or Accept-Language headers mismatch");
+    }
+
     if linkHeaders.length() == 0 {
         return error ResourceDiscoveryFailedError("Link header unavailable in discovery response");
     }

--- a/websub-ballerina/tests/basic_subscriber_test.bal
+++ b/websub-ballerina/tests/basic_subscriber_test.bal
@@ -86,16 +86,12 @@ function testOnIntentVerificationSuccess() returns @tainted error? {
 @test:Config { 
     groups: ["simpleSubscriber"]
 }
-function testOnIntentVerificationFailure() {
-    http:Response|error response = httpClient->get("/?hub.mode=subscribe&hub.topic=test1&hub.challenge=1234");
-    if (response is http:ClientRequestError) {
-        test:assertEquals(response.detail().statusCode, 404, msg = "Found unexpected output");
-        string payload = <string> response.detail().body;
-        map<string> responseBody = decodeResponseBody(payload);
-        test:assertEquals(responseBody["reason"], "Subscription verification failed");
-    } else {
-        test:assertFail("Found unexpected output");
-    }
+function testOnIntentVerificationFailure() returns @tainted error? {
+    http:Response response = check httpClient->get("/?hub.mode=subscribe&hub.topic=test1&hub.challenge=1234");
+    test:assertEquals(response.statusCode, 404);
+    string payload = check response.getTextPayload();
+    map<string> responseBody = decodeResponseBody(payload);
+    test:assertEquals(responseBody["reason"], "Subscription verification failed");
 }
 
 @test:Config {

--- a/websub-ballerina/tests/multi_service_listener_test.bal
+++ b/websub-ballerina/tests/multi_service_listener_test.bal
@@ -91,31 +91,23 @@ function testOnSubscriptionValidationWithServiceTwo() returns @tainted error? {
 @test:Config { 
     groups: ["multiServiceListener"]
 }
-function testOnIntentVerificationFailureServiceOne() {
-    http:Response|error response = clientForServiceOne->get("/?hub.mode=subscribe&hub.topic=test1&hub.challenge=1234");
-    if (response is http:ClientRequestError) {
-        test:assertEquals(response.detail().statusCode, 404, msg = "Found unexpected output");
-        string payload = <string> response.detail().body;
-        map<string> responseBody = decodeResponseBody(payload);
-        test:assertEquals(responseBody["reason"], "Subscription verification failed");
-    } else {
-        test:assertFail("Found unexpected output");
-    }
+function testOnIntentVerificationFailureServiceOne() returns @tainted error? {
+    http:Response response = check clientForServiceOne->get("/?hub.mode=subscribe&hub.topic=test1&hub.challenge=1234");
+    test:assertEquals(response.statusCode, 404);
+    string payload = check response.getTextPayload();
+    map<string> responseBody = decodeResponseBody(payload);
+    test:assertEquals(responseBody["reason"], "Subscription verification failed");
 }
 
 @test:Config { 
     groups: ["multiServiceListener"]
 }
-function testOnIntentVerificationFailureServiceTwo() {
-    http:Response|error response = clientForServiceTwo->get("/?hub.mode=subscribe&hub.topic=test1&hub.challenge=1234");
-    if (response is http:ClientRequestError) {
-        test:assertEquals(response.detail().statusCode, 404, msg = "Found unexpected output");
-        string payload = <string> response.detail().body;
-        map<string> responseBody = decodeResponseBody(payload);
-        test:assertEquals(responseBody["reason"], "Subscription verification failed");
-    } else {
-        test:assertFail("Found unexpected output");
-    }
+function testOnIntentVerificationFailureServiceTwo() returns @tainted error? {
+    http:Response response = check clientForServiceTwo->get("/?hub.mode=subscribe&hub.topic=test1&hub.challenge=1234");
+    test:assertEquals(response.statusCode, 404);
+    string payload = check response.getTextPayload();
+    map<string> responseBody = decodeResponseBody(payload);
+    test:assertEquals(responseBody["reason"], "Subscription verification failed");
 }
 
 @test:Config {

--- a/websub-ballerina/tests/ssl_enabled_subscriber_test.bal
+++ b/websub-ballerina/tests/ssl_enabled_subscriber_test.bal
@@ -84,16 +84,12 @@ function testOnIntentVerificationSuccessWithSsl() returns @tainted error? {
 @test:Config { 
     groups: ["sslEnabledSubscriber"]
 }
-function testOnIntentVerificationFailureWithSsl() {
-    http:Response|error response = sslEnabledClient->get("/?hub.mode=subscribe&hub.topic=test1&hub.challenge=1234");
-    if (response is http:ClientRequestError) {
-        test:assertEquals(response.detail().statusCode, 404, msg = "Found unexpected output");
-        string payload = <string> response.detail().body;
-        map<string> responseBody = decodeResponseBody(payload);
-        test:assertEquals(responseBody["reason"], "Subscription verification failed");
-    } else {
-        test:assertFail("Found unexpected output");
-    }
+function testOnIntentVerificationFailureWithSsl() returns @tainted error? {
+    http:Response response = check sslEnabledClient->get("/?hub.mode=subscribe&hub.topic=test1&hub.challenge=1234");
+    test:assertEquals(response.statusCode, 404);
+    string payload = check response.getTextPayload();
+    map<string> responseBody = decodeResponseBody(payload);
+    test:assertEquals(responseBody["reason"], "Subscription verification failed");
 }
 
 @test:Config {

--- a/websub-ballerina/tests/subscriber_with_error_return_types.bal
+++ b/websub-ballerina/tests/subscriber_with_error_return_types.bal
@@ -60,16 +60,10 @@ function testOnSubscriptionValidationWithErrorReturnType() returns @tainted erro
 @test:Config {
     groups: ["subscriberWithErrorReturns"]
  }
-function testOnIntentVerificationSuccessWithErrorReturnType() {
-    http:Response|error response = SubscriberWithErrorReturnsClientEp->get("/?hub.mode=subscribe&hub.topic=test&hub.challenge=1234");
-    if (response is http:ClientRequestError) {
-        test:assertEquals(response.detail().statusCode, 404, msg = "Found unexpected output");
-        string payload = <string> response.detail().body;
-        map<string> responseBody = decodeResponseBody(payload);
-        test:assertEquals(responseBody["reason"], "Error occured while processing request");
-    } else {
-        test:assertFail("Found unexpected output");
-    }
+function testOnIntentVerificationSuccessWithErrorReturnType() returns @tainted error? {
+    http:Response response = check SubscriberWithErrorReturnsClientEp->get("/?hub.mode=subscribe&hub.topic=test&hub.challenge=1234");
+    test:assertEquals(response.statusCode, 404);
+    test:assertEquals(response.getTextPayload(), "reason=Error occured while processing request");
 }
 
 @test:Config {

--- a/websub-ballerina/tests/websub_config_manual_attach_test.bal
+++ b/websub-ballerina/tests/websub_config_manual_attach_test.bal
@@ -82,16 +82,12 @@ function testOnIntentVerificationSuccessWithManualConfigAttach() returns @tainte
 @test:Config { 
     groups: ["manualConfigAttach"]
 }
-function testOnIntentVerificationFailureWithManualConfigAttach() {
-    http:Response|error response = manualConfigAttachClientEp->get("/?hub.mode=subscribe&hub.topic=test1&hub.challenge=1234");
-    if (response is http:ClientRequestError) {
-        test:assertEquals(response.detail().statusCode, 404, msg = "Found unexpected output");
-        string payload = <string> response.detail().body;
-        map<string> responseBody = decodeResponseBody(payload);
-        test:assertEquals(responseBody["reason"], "Subscription verification failed");
-    } else {
-        test:assertFail("Found unexpected output");
-    }
+function testOnIntentVerificationFailureWithManualConfigAttach() returns @tainted error? {
+    http:Response response = check manualConfigAttachClientEp->get("/?hub.mode=subscribe&hub.topic=test1&hub.challenge=1234");
+    test:assertEquals(response.statusCode, 404);
+    string payload = check response.getTextPayload();
+    map<string> responseBody = decodeResponseBody(payload);
+    test:assertEquals(responseBody["reason"], "Subscription verification failed");
 }
 
 @test:Config {


### PR DESCRIPTION
## Purpose
> $subject

This reverts [b91f5c9](https://github.com/ballerina-platform/module-ballerina-websub/pull/263/commits/b91f5c96713568946a88959d9c734ccbdd4854c3)

Related to [#425](https://github.com/ballerina-platform/module-ballerina-http/pull/425)

## Checklist
~~Linked to an issue~~ N/A
~~Updated the changelog~~ N/A
~~Added tests~~ N/A
