### PR TITLE
Upgrade Netty and TCNative Version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@ version=1.2.0-beta.2-SNAPSHOT
 ballerinaLangVersion=2.0.0-beta.2-20210615-105400-5804ecbf
 
 ballerinaTomlParserVersion=1.2.2
-nettyVersion=4.1.50.Final
-nettyTcnativeVersion=2.0.31.Final
+nettyVersion=4.1.65.Final
+nettyTcnativeVersion=2.0.39.Final
 bouncycastleVersion=1.61
 puppycrawlCheckstyleVersion=8.18
 slf4jVersion=1.7.30


### PR DESCRIPTION
## Purpose
> Netty : 4.1.65.Final
> TCNative: 2.0.39.Final

Related to [#1446](https://github.com/ballerina-platform/ballerina-standard-library/issues/1446)

## Checklist
- [X] Linked to an issue
~~Updated the changelog~~ N/A
~~Added tests~~ N/A
