### PR TITLE
Util method to retrieve http-headers from content-distribution message

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Log error when return from the remote method leads to an error](https://github.com/ballerina-platform/ballerina-standard-library/issues/1450)
 - [WebSubHub Compiler Plugin does not allow additional methods inside service declaration](https://github.com/ballerina-platform/ballerina-standard-library/issues/1417)
+- [Util method to retrieve HTTP Headers from `onEventNotification` payload](https://github.com/ballerina-platform/ballerina-standard-library/issues/1484)
 
 ## [1.2.0-beta.1] - 2021-05-06
 

--- a/websub-ballerina/native.bal
+++ b/websub-ballerina/native.bal
@@ -14,6 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/http;
 import ballerina/jballerina.java;
 
 isolated class HttpToWebsubAdaptor {
@@ -35,12 +36,16 @@ isolated class HttpToWebsubAdaptor {
         'class: "io.ballerina.stdlib.websub.NativeHttpToWebsubAdaptor"
     } external;
 
-    isolated function callOnEventNotificationMethod(ContentDistributionMessage msg)
+    isolated function callOnEventNotificationMethod(ContentDistributionMessage msg, http:Request request)
                                     returns Acknowledgement|SubscriptionDeletedError|error? = @java:Method {
         'class: "io.ballerina.stdlib.websub.NativeHttpToWebsubAdaptor"
     } external;
 }
 
 isolated function externInit(HttpToWebsubAdaptor adaptor, SubscriberService serviceObj) = @java:Method {
+    'class: "io.ballerina.stdlib.websub.NativeHttpToWebsubAdaptor"
+} external;
+
+isolated function retrieveHttpRequest(ContentDistributionMessage msg) returns http:Request = @java:Method {
     'class: "io.ballerina.stdlib.websub.NativeHttpToWebsubAdaptor"
 } external;

--- a/websub-ballerina/request_processor.bal
+++ b/websub-ballerina/request_processor.bal
@@ -147,7 +147,7 @@ isolated function processEventNotification(http:Caller caller, http:Request requ
         response.statusCode = http:STATUS_BAD_REQUEST;
         return;
     } else {
-        Acknowledgement|SubscriptionDeletedError|error? result = adaptor.callOnEventNotificationMethod(message);
+        Acknowledgement|SubscriptionDeletedError|error? result = adaptor.callOnEventNotificationMethod(message, request);
         if result is Acknowledgement {
             updateResponseBody(response, result["body"], result["headers"]);
         } else if result is SubscriptionDeletedError {

--- a/websub-ballerina/request_processor.bal
+++ b/websub-ballerina/request_processor.bal
@@ -37,7 +37,7 @@ isolated function processSubscriptionVerification(http:Caller caller, http:Respo
         hubLeaseSeconds: params?.hubLeaseSeconds
     };
 
-    SubscriptionVerificationSuccess|SubscriptionVerificationError|error result = adaptor.callOnSubscriptionVerificationMethod(message);
+    SubscriptionVerificationSuccess|error result = adaptor.callOnSubscriptionVerificationMethod(message);
     if result is SubscriptionVerificationError {
         response.statusCode = http:STATUS_NOT_FOUND;
         var errorDetails = result.detail();
@@ -147,7 +147,7 @@ isolated function processEventNotification(http:Caller caller, http:Request requ
         response.statusCode = http:STATUS_BAD_REQUEST;
         return;
     } else {
-        Acknowledgement|SubscriptionDeletedError|error? result = adaptor.callOnEventNotificationMethod(message, request);
+        Acknowledgement|error? result = adaptor.callOnEventNotificationMethod(message, request);
         if result is Acknowledgement {
             updateResponseBody(response, result["body"], result["headers"]);
         } else if result is SubscriptionDeletedError {

--- a/websub-ballerina/tests/utils_test.bal
+++ b/websub-ballerina/tests/utils_test.bal
@@ -16,6 +16,7 @@
 
 import ballerina/test;
 import ballerina/http;
+import ballerina/mime;
 
 const string HASH_KEY = "secret";
 
@@ -255,4 +256,70 @@ isolated function testCallbackUrlLoggingFailure() returns @tainted error? {
 isolated function testCallbackUrlLoggingFailureForServicePathProvided() returns @tainted error? {
     boolean isLoggingEnabled = isLoggingGeneratedCallback((), "subscriber");
     test:assertFalse(isLoggingEnabled, "Callback URL logging is enabled for invalid scenario");
+}
+
+@SubscriberServiceConfig{}
+service /subscriber on new Listener(9101) {
+    isolated remote function onEventNotification(ContentDistributionMessage event) returns Acknowledgement {
+        string|http:HeaderNotFoundError headerValue = getHeader(event, "Custom-Header");
+        if (headerValue is string) {
+            return {
+                body: {
+                    "Custom-Header": headerValue
+                }
+            };
+        } else {
+            return {
+                body: {
+                    "Message": "Header Not Found"
+                }
+            };
+        }
+    }
+}
+
+final http:Client headerUtilTestClient = check new ("http://localhost:9101/subscriber");
+
+@test:Config { 
+    groups: ["requestHeader"]
+}
+isolated function testRequestHeaderRetrievalWithStandardHeadeName() returns @tainted error? {
+    http:Request request = new;
+    request.setHeader("Custom-Header", "Custom Header Value");
+    request.setTextPayload("This is a sample message");
+    http:Response response = check headerUtilTestClient->post("/", request);
+    string payload = check response.getTextPayload();
+    map<string> decodedPayload = decodeResponseBody(payload);
+    test:assertEquals(response.statusCode, 202);
+    test:assertEquals(response.getContentType(), mime:APPLICATION_FORM_URLENCODED);
+    test:assertEquals(decodedPayload.get("Custom-Header"), "Custom Header Value");
+}
+
+@test:Config { 
+    groups: ["requestHeader"]
+}
+isolated function testRequestHeaderRetrievalWithNonStandardHeadeName() returns @tainted error? {
+    http:Request request = new;
+    request.setHeader("custoM-HeaDer", "Custom Header Value");
+    request.setTextPayload("This is a sample message");
+    http:Response response = check headerUtilTestClient->post("/", request);
+    string payload = check response.getTextPayload();
+    map<string> decodedPayload = decodeResponseBody(payload);
+    test:assertEquals(response.statusCode, 202);
+    test:assertEquals(response.getContentType(), mime:APPLICATION_FORM_URLENCODED);
+    test:assertEquals(decodedPayload.get("Custom-Header"), "Custom Header Value");
+}
+
+@test:Config { 
+    groups: ["requestHeader"]
+}
+isolated function testRequestHeaderRetrievalWithoutHeaderValue() returns @tainted error? {
+    http:Request request = new;
+    request.setTextPayload("This is a sample message");
+    http:Response response = check headerUtilTestClient->post("/", request);
+    string payload = check response.getTextPayload();
+    map<string> decodedPayload = decodeResponseBody(payload);
+    test:assertEquals(response.statusCode, 202);
+    test:assertEquals(response.getContentType(), mime:APPLICATION_FORM_URLENCODED);
+    test:assertEquals(decodedPayload.get("Message"), "Header Not Found");
 }

--- a/websub-ballerina/tests/utils_test.bal
+++ b/websub-ballerina/tests/utils_test.bal
@@ -258,8 +258,11 @@ isolated function testCallbackUrlLoggingFailureForServicePathProvided() returns 
     test:assertFalse(isLoggingEnabled, "Callback URL logging is enabled for invalid scenario");
 }
 
+
+listener Listener utilTestListener = new (9101);
+
 @SubscriberServiceConfig{}
-service /subscriber on new Listener(9101) {
+service /utilTest1 on utilTestListener {
     isolated remote function onEventNotification(ContentDistributionMessage event) returns Acknowledgement {
         string|http:HeaderNotFoundError headerValue = getHeader(event, "Custom-Header");
         if (headerValue is string) {
@@ -278,7 +281,28 @@ service /subscriber on new Listener(9101) {
     }
 }
 
-final http:Client headerUtilTestClient = check new ("http://localhost:9101/subscriber");
+@SubscriberServiceConfig{}
+service /utilTest2 on utilTestListener {
+    isolated remote function onEventNotification(ContentDistributionMessage event) returns Acknowledgement {
+        string[]|http:HeaderNotFoundError values = getHeaders(event, "Custom-Header");
+        if (values is string[]) {
+            string concatenatedValues = string:'join(",", ...values);
+            return {
+                body: {
+                    "Custom-Header": concatenatedValues
+                }
+            };
+        } else {
+            return {
+                body: {
+                    "Message": "Header Not Found"
+                }
+            };
+        }
+    }
+}
+
+final http:Client headerUtilTestClient1 = check new ("http://localhost:9101/utilTest1");
 
 @test:Config { 
     groups: ["requestHeader"]
@@ -287,7 +311,7 @@ isolated function testRequestHeaderRetrievalWithStandardHeadeName() returns @tai
     http:Request request = new;
     request.setHeader("Custom-Header", "Custom Header Value");
     request.setTextPayload("This is a sample message");
-    http:Response response = check headerUtilTestClient->post("/", request);
+    http:Response response = check headerUtilTestClient1->post("/", request);
     string payload = check response.getTextPayload();
     map<string> decodedPayload = decodeResponseBody(payload);
     test:assertEquals(response.statusCode, 202);
@@ -302,7 +326,7 @@ isolated function testRequestHeaderRetrievalWithNonStandardHeadeName() returns @
     http:Request request = new;
     request.setHeader("custoM-HeaDer", "Custom Header Value");
     request.setTextPayload("This is a sample message");
-    http:Response response = check headerUtilTestClient->post("/", request);
+    http:Response response = check headerUtilTestClient1->post("/", request);
     string payload = check response.getTextPayload();
     map<string> decodedPayload = decodeResponseBody(payload);
     test:assertEquals(response.statusCode, 202);
@@ -316,7 +340,57 @@ isolated function testRequestHeaderRetrievalWithNonStandardHeadeName() returns @
 isolated function testRequestHeaderRetrievalWithoutHeaderValue() returns @tainted error? {
     http:Request request = new;
     request.setTextPayload("This is a sample message");
-    http:Response response = check headerUtilTestClient->post("/", request);
+    http:Response response = check headerUtilTestClient1->post("/", request);
+    string payload = check response.getTextPayload();
+    map<string> decodedPayload = decodeResponseBody(payload);
+    test:assertEquals(response.statusCode, 202);
+    test:assertEquals(response.getContentType(), mime:APPLICATION_FORM_URLENCODED);
+    test:assertEquals(decodedPayload.get("Message"), "Header Not Found");
+}
+
+final http:Client headerUtilTestClient2 = check new ("http://localhost:9101/utilTest2");
+
+@test:Config { 
+    groups: ["requestHeader"]
+}
+isolated function testRequestHeadersRetrievalWithStandardHeadeName() returns @tainted error? {
+    http:Request request = new;
+    request.addHeader("Custom-Header", "Val1");
+    request.addHeader("Custom-Header", "Val2");
+    request.addHeader("Custom-Header", "Val3");
+    request.setTextPayload("This is a sample message");
+    http:Response response = check headerUtilTestClient2->post("/", request);
+    string payload = check response.getTextPayload();
+    map<string> decodedPayload = decodeResponseBody(payload);
+    test:assertEquals(response.statusCode, 202);
+    test:assertEquals(response.getContentType(), mime:APPLICATION_FORM_URLENCODED);
+    test:assertEquals(decodedPayload.get("Custom-Header"), "Val1,Val2,Val3");
+}
+
+@test:Config { 
+    groups: ["requestHeader"]
+}
+isolated function testRequestHeadersRetrievalWithNonStandardHeadeName() returns @tainted error? {
+    http:Request request = new;
+    request.addHeader("custoM-HeaDer", "Val1");
+    request.addHeader("custoM-HeaDer", "Val2");
+    request.addHeader("custoM-HeaDer", "Val3");
+    request.setTextPayload("This is a sample message");
+    http:Response response = check headerUtilTestClient2->post("/", request);
+    string payload = check response.getTextPayload();
+    map<string> decodedPayload = decodeResponseBody(payload);
+    test:assertEquals(response.statusCode, 202);
+    test:assertEquals(response.getContentType(), mime:APPLICATION_FORM_URLENCODED);
+    test:assertEquals(decodedPayload.get("Custom-Header"), "Val1,Val2,Val3");
+}
+
+@test:Config { 
+    groups: ["requestHeader"]
+}
+isolated function testRequestHeadersRetrievalWithoutHeaderValue() returns @tainted error? {
+    http:Request request = new;
+    request.setTextPayload("This is a sample message");
+    http:Response response = check headerUtilTestClient2->post("/", request);
     string payload = check response.getTextPayload();
     map<string> decodedPayload = decodeResponseBody(payload);
     test:assertEquals(response.statusCode, 202);

--- a/websub-ballerina/utils.bal
+++ b/websub-ballerina/utils.bal
@@ -262,3 +262,14 @@ public isolated function getHeader(ContentDistributionMessage msg, string header
     http:Request originalRequest = retrieveHttpRequest(msg);
     return originalRequest.getHeader(headerName);
 }
+
+# Gets all the header values to which the specified header key maps to.
+#
+# + msg - Current `websub:ContentDistributionMessage` object
+# + headerName - The header name
+# + return - The header values the specified header key maps to or the `http:HeaderNotFoundError` if the header is not
+#            found.
+public isolated function getHeaders(ContentDistributionMessage msg, string headerName) returns string[]|http:HeaderNotFoundError {
+    http:Request originalRequest = retrieveHttpRequest(msg);
+    return originalRequest.getHeaders(headerName);
+}

--- a/websub-ballerina/utils.bal
+++ b/websub-ballerina/utils.bal
@@ -250,3 +250,15 @@ isolated function respondToRequest(http:Caller caller, http:Response response) {
 isolated function isSuccessStatusCode(int statusCode) returns boolean {
     return (200 <= statusCode && statusCode < 300);
 }
+
+# Returns the value of the specified header. If the specified header key maps to multiple values, the first of
+# these values is returned.
+#
+# + msg - Current `websub:ContentDistributionMessage` object
+# + headerName - The header name
+# + return - The first header value for the specified header name or the `http:HeaderNotFoundError` if the header is not
+#            found.
+public isolated function getHeader(ContentDistributionMessage msg, string headerName) returns string|http:HeaderNotFoundError {
+    http:Request originalRequest = retrieveHttpRequest(msg);
+    return originalRequest.getHeader(headerName);
+}

--- a/websub-native/src/main/java/io/ballerina/stdlib/websub/Constants.java
+++ b/websub-native/src/main/java/io/ballerina/stdlib/websub/Constants.java
@@ -26,4 +26,5 @@ public interface Constants {
     String PACKAGE_NAME = "websub";
 
     String SERVICE_OBJECT = "WEBSUB_SERVICE_OBJECT";
+    String HTTP_REQUEST = "HTTP_REQUEST";
 }

--- a/websub-native/src/main/java/io/ballerina/stdlib/websub/NativeHttpToWebsubAdaptor.java
+++ b/websub-native/src/main/java/io/ballerina/stdlib/websub/NativeHttpToWebsubAdaptor.java
@@ -33,6 +33,7 @@ import io.ballerina.runtime.api.values.BString;
 
 import java.util.ArrayList;
 
+import static io.ballerina.stdlib.websub.Constants.HTTP_REQUEST;
 import static io.ballerina.stdlib.websub.Constants.SERVICE_OBJECT;
 
 /**
@@ -66,10 +67,15 @@ public class NativeHttpToWebsubAdaptor {
     }
 
     public static Object callOnEventNotificationMethod(Environment env, BObject adaptor,
-                                                       BMap<BString, Object> message) {
+                                                       BMap<BString, Object> message, BObject bHttpRequest) {
+        message.addNativeData(HTTP_REQUEST, bHttpRequest);
         BObject serviceObj = (BObject) adaptor.getNativeData(SERVICE_OBJECT);
         return invokeRemoteFunction(env, serviceObj, message,
                 "callOnEventNotificationMethod", "onEventNotification");
+    }
+
+    public static BObject retrieveHttpRequest(BMap<BString, Object> message) {
+        return (BObject) message.getNativeData(HTTP_REQUEST);
     }
 
     private static Object invokeRemoteFunction(Environment env, BObject bSubscriberService, Object message,


### PR DESCRIPTION
## Purpose
> $subject

Fixes [#1484](https://github.com/ballerina-platform/ballerina-standard-library/issues/1484)

## Examples
To retrieve only the first header value: 
```ballerina
@websub:SubscriberServiceConfig{
  // add the required configuration
}
service /subscriber on new Listener(9101) {
    isolated remote function onEventNotification(websub:ContentDistributionMessage event) returns websub:Acknowledgement {
        string|http:HeaderNotFoundError headerValue = getHeader(event, "Custom-Header");
        // implement the logic here
    }
}
```

To retrieve all the header values to which the specified header key maps to:
```ballerina
@websub:SubscriberServiceConfig{
  // add the required configuration
}
service /subscriber on new Listener(9101) {
    isolated remote function onEventNotification(websub:ContentDistributionMessage event) returns websub:Acknowledgement {
        string[]|http:HeaderNotFoundError values = getHeaders(event, "Custom-Header");
        // implement the logic here
    }
}
```

## Checklist
- [X] Linked to an issue
- [X] Updated the changelog
- [X] Added tests
