### PR TITLE
Add trivy scan for release builds and add daily trivy scan build

### DIFF
--- a/.github/workflows/central-publish.yml
+++ b/.github/workflows/central-publish.yml
@@ -13,8 +13,18 @@ jobs:
           uses: actions/setup-java@v1
           with:
             java-version: 11
-      -   name: Grant execute permission for gradlew
-          run: chmod +x gradlew
+      - name: Build with Gradle
+        env:
+          packageUser: ${{ github.actor }}
+          packagePAT: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew build -x check -x test
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          scan-ref: '/github/workspace/ballerina/lib'
+          format: 'table'
+          exit-code: '1'
       -   name: Publish artifact
           env:
             BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_ACCESS_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -16,6 +16,18 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: '11'
+      - name: Build with Gradle
+        env:
+          packageUser: ${{ github.actor }}
+          packagePAT: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew build -x check -x test
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          scan-ref: '/github/workspace/ballerina/lib'
+          format: 'table'
+          exit-code: '1'
       - name: Set version env variable
         run: echo "VERSION=$((grep -w 'version' | cut -d= -f2) < gradle.properties | rev | cut --complement -d- -f1 | rev)" >> $GITHUB_ENV
       - name : Pre release depenency version update
@@ -32,8 +44,6 @@ jobs:
           sed -i 's/stdlib\(.*\)=\(.*\)-[0-9]\{8\}-[0-9]\{6\}-.*$/stdlib\1=\2/g' gradle.properties
           git add gradle.properties
           git commit -m "Move dependencies to stable version" || echo "No changes to commit"
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
       - name: Publish artifact
         env:
           BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_ACCESS_TOKEN }}

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -1,0 +1,30 @@
+name: Trivy
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 0 * * *'
+
+jobs:
+  ubuntu-build:
+    name: Build on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: 11
+      - name: Build with Gradle
+        env:
+          packageUser: ${{ github.actor }}
+          packagePAT: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew build -x check -x test
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          scan-ref: '/github/workspace/ballerina/lib'
+          format: 'table'
+          exit-code: '1'

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Ballerina WebSub Library
 ===================
 
   [![Build](https://github.com/ballerina-platform/module-ballerina-websub/actions/workflows/build-timestamped-master.yml/badge.svg)](https://github.com/ballerina-platform/module-ballerina-websub/actions/workflows/build-timestamped-master.yml)
+  [![Trivy](https://github.com/ballerina-platform/module-ballerina-websub/actions/workflows/trivy-scan.yml/badge.svg)](https://github.com/ballerina-platform/module-ballerina-crypto/actions/workflows/trivy-scan.yml)  
   [![GitHub Last Commit](https://img.shields.io/github/last-commit/ballerina-platform/module-ballerina-websub.svg)](https://github.com/ballerina-platform/module-ballerina-websub/commits/master)
   [![Github issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-standard-library/module/websub.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-standard-library/labels/module%2Fwebsub)
   [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Ballerina WebSub Library
   [![Trivy](https://github.com/ballerina-platform/module-ballerina-websub/actions/workflows/trivy-scan.yml/badge.svg)](https://github.com/ballerina-platform/module-ballerina-crypto/actions/workflows/trivy-scan.yml)  
   [![GitHub Last Commit](https://img.shields.io/github/last-commit/ballerina-platform/module-ballerina-websub.svg)](https://github.com/ballerina-platform/module-ballerina-websub/commits/master)
   [![Github issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-standard-library/module/websub.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-standard-library/labels/module%2Fwebsub)
-  [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
   [![codecov](https://codecov.io/gh/ballerina-platform/module-ballerina-websub/branch/master/graph/badge.svg)](https://codecov.io/gh/ballerina-platform/module-ballerina-websub)
 
 The WebSub package is one of the standard library packages of the <a target="_blank" href="https://ballerina.io/">Ballerina</a> language.


### PR DESCRIPTION
## Purpose
This PR integrates the [Trivy](https://github.com/aquasecurity/trivy) vulnerability scanner for the repository file system and it will check and generate the report daily or on-demand and before the release.

Related Issue: [#1849](https://github.com/ballerina-platform/ballerina-standard-library/issues/1849)

## Checklist
- [x] Linked to an issue
- [ ] ~Updated the changelog~
- [ ] ~Added tests~
