### PR TITLE
Notify user of Subscription denial from the `hub` when `onSubscriptionDenied` is not implemented

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "websub"
-version = "2.1.0"
+version = "2.1.1"
 authors = ["Ballerina"]
 keywords = ["websub", "subscriber", "service", "listener"]
 repository = "https://github.com/ballerina-platform/module-ballerina-websub"
@@ -9,4 +9,4 @@ license = ["Apache-2.0"]
 distribution = "slbeta6"
 
 [[platform.java11.dependency]]
-path = "../native/build/libs/websub-native-2.1.0.jar"
+path = "../native/build/libs/websub-native-2.1.1-SNAPSHOT.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "websub-compiler-plugin"
 class = "io.ballerina.stdlib.websub.WebSubCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/websub-compiler-plugin-2.1.0.jar"
+path = "../compiler-plugin/build/libs/websub-compiler-plugin-2.1.1-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -314,7 +314,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "websub"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "http"},

--- a/ballerina/http_service.bal
+++ b/ballerina/http_service.bal
@@ -93,6 +93,7 @@ isolated service class HttpService {
                 if self.isSubscriptionValidationDeniedAvailable {
                     processSubscriptionDenial(caller, response, params, self.adaptor);
                 } else {
+                    log:printWarn("Subscription is denied by the hub");
                     response.statusCode = http:STATUS_OK;
                     updateResponseBody(response, ACKNOWLEDGEMENT["body"], ACKNOWLEDGEMENT["headers"]);
                 }

--- a/ballerina/http_service.bal
+++ b/ballerina/http_service.bal
@@ -93,7 +93,7 @@ isolated service class HttpService {
                 if self.isSubscriptionValidationDeniedAvailable {
                     processSubscriptionDenial(caller, response, params, self.adaptor);
                 } else {
-                    log:printWarn("Subscription is denied by the hub");
+                    log:printError("Subscription is denied by the hub");
                     response.statusCode = http:STATUS_OK;
                     updateResponseBody(response, ACKNOWLEDGEMENT["body"], ACKNOWLEDGEMENT["headers"]);
                 }

--- a/ballerina/tests/unsubscription_test.bal
+++ b/ballerina/tests/unsubscription_test.bal
@@ -84,7 +84,8 @@ service object {
 function testUnsubscriptionOnGracefulStop() returns error? {
     check unsubscriptionTestListener.attach(unsubscriptionTestSubscriber, "sub");
     check unsubscriptionTestListener.'start();
-    check unsubscriptionTestListener.gracefulStop();
     runtime:sleep(1);
+    check unsubscriptionTestListener.gracefulStop();
+    runtime:sleep(5);
     test:assertTrue(isVerified());
 }

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- [Notify user of Subscription denial from the `hub` when `onSubscriptionDenied` is not implemented](https://github.com/ballerina-platform/ballerina-standard-library/issues/2448)  
+
+## [2.0.1] - 2021-11-19
+
 ### Changed
 - [Generated unique-service-path should not be changed after compilation](https://github.com/ballerina-platform/ballerina-standard-library/issues/1813)
 - [Mark WebSub Service type as distinct](https://github.com/ballerina-platform/ballerina-standard-library/issues/2398)


### PR DESCRIPTION
## Purpose
> $subject

Fixed [#2448](https://github.com/ballerina-platform/ballerina-standard-library/issues/2448)

## Examples
If the developer has not implemented the `onSubscriptionDenied` method as in following sample:
```ballerina
@websub:SubscriberServiceConfig { 
    target: ["https://sample.hub.com", "https://sample.topic.com"],
} 
service on securedSubscriber {
    remote function onEventNotification(websub:ContentDistributionMessage event) returns websub:Acknowledgement{
        log:printInfo("onEventNotification invoked ", contentDistributionMessage = event);
        return websub:ACKNOWLEDGEMENT;
    }
}
```

There will be a log line printed if the subscription request is denied by the hub:
```sh
ERROR module = ballerina/websub message = "Subscription is denied by the hub"
```


## Checklist
- [X] Linked to an issue
- [X] Updated the changelog
- [ ] Added tests
