### PR TITLE
`readonly` support for the parameters of remote methods

### DIFF
--- a/ballerina/tests/subscriber_with_readonly_method_params_test.bal
+++ b/ballerina/tests/subscriber_with_readonly_method_params_test.bal
@@ -48,7 +48,7 @@ service /subscriber on new Listener(9104) {
 
     isolated remote function onEventNotification(readonly & ContentDistributionMessage event)
                         returns Acknowledgement|SubscriptionDeletedError? {
-        test:assertTrue(msg is readonly);
+        test:assertTrue(event is readonly);
         match event.contentType {
             mime:APPLICATION_FORM_URLENCODED => {
                 map<string> content = <map<string>>event.content;

--- a/ballerina/tests/subscriber_with_readonly_method_params_test.bal
+++ b/ballerina/tests/subscriber_with_readonly_method_params_test.bal
@@ -22,11 +22,13 @@ import ballerina/http;
 @SubscriberServiceConfig {}
 service /subscriber on new Listener(9104) {
     isolated remote function onSubscriptionValidationDenied(readonly & SubscriptionDeniedError msg) returns Acknowledgement? {
+        test:assertTrue(msg is readonly);
         return ACKNOWLEDGEMENT;
     }
 
     isolated remote function onSubscriptionVerification(readonly & SubscriptionVerification msg)
                         returns SubscriptionVerificationSuccess|SubscriptionVerificationError {
+        test:assertTrue(msg is readonly);
         if (msg.hubTopic == "test1") {
             return SUBSCRIPTION_VERIFICATION_ERROR;
         } else {
@@ -36,6 +38,7 @@ service /subscriber on new Listener(9104) {
 
     remote function onUnsubscriptionVerification(readonly & UnsubscriptionVerification msg)
                     returns UnsubscriptionVerificationSuccess|UnsubscriptionVerificationError {
+        test:assertTrue(msg is readonly);
         if (msg.hubTopic == "test1") {
             return UNSUBSCRIPTION_VERIFICATION_ERROR;
         } else {
@@ -45,6 +48,7 @@ service /subscriber on new Listener(9104) {
 
     isolated remote function onEventNotification(readonly & ContentDistributionMessage event)
                         returns Acknowledgement|SubscriptionDeletedError? {
+        test:assertTrue(msg is readonly);
         match event.contentType {
             mime:APPLICATION_FORM_URLENCODED => {
                 map<string> content = <map<string>>event.content;

--- a/ballerina/tests/subscriber_with_readonly_method_params_test.bal
+++ b/ballerina/tests/subscriber_with_readonly_method_params_test.bal
@@ -1,0 +1,81 @@
+// Copyright (c) 2022 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/log;
+import ballerina/test;
+import ballerina/mime;
+import ballerina/http;
+
+@SubscriberServiceConfig {}
+service /subscriber on new Listener(9104) {
+    isolated remote function onSubscriptionValidationDenied(readonly & SubscriptionDeniedError msg) returns Acknowledgement? {
+        return ACKNOWLEDGEMENT;
+    }
+
+    isolated remote function onSubscriptionVerification(readonly & SubscriptionVerification msg)
+                        returns SubscriptionVerificationSuccess|SubscriptionVerificationError {
+        if (msg.hubTopic == "test1") {
+            return SUBSCRIPTION_VERIFICATION_ERROR;
+        } else {
+            return SUBSCRIPTION_VERIFICATION_SUCCESS;
+        }
+    }
+
+    isolated remote function onEventNotification(readonly & ContentDistributionMessage event)
+                        returns Acknowledgement|SubscriptionDeletedError? {
+        match event.contentType {
+            mime:APPLICATION_FORM_URLENCODED => {
+                map<string> content = <map<string>>event.content;
+                log:printInfo("URL encoded content received ", content = content);
+            }
+            _ => {
+                log:printDebug("onEventNotification invoked ", contentDistributionMessage = event);
+            }
+        }
+
+        return ACKNOWLEDGEMENT;
+    }
+}
+
+http:Client readonlyParamTestClient = check new ("http://localhost:9104/subscriber");
+
+@test:Config {
+    groups: ["subscriberWithReadonlyParams"]
+}
+function testOnSubscriptionValidationWithReadonly() returns error? {
+    http:Response response = check readonlyParamTestClient->get("/?hub.mode=denied&hub.reason=justToTest");
+    test:assertEquals(response.statusCode, 200);
+}
+
+@test:Config {
+    groups: ["subscriberWithReadonlyParams"]
+}
+function testOnIntentVerificationSuccessWithReadonly() returns error? {
+    http:Response response = check readonlyParamTestClient->get("/?hub.mode=subscribe&hub.topic=test&hub.challenge=1234");
+    test:assertEquals(response.statusCode, 200);
+    test:assertEquals(response.getTextPayload(), "1234");
+}
+
+@test:Config {
+    groups: ["subscriberWithReadonlyParams"]
+}
+function testOnEventNotificationSuccessWithReadonly() returns error? {
+    http:Request request = new;
+    json payload = {"action": "publish", "mode": "remote-hub"};
+    request.setPayload(payload);
+    http:Response response = check readonlyParamTestClient->post("/", request);
+    test:assertEquals(response.statusCode, 202);
+}

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- [WebSub/WebSubHub should support `readonly` parameters for remote methods](https://github.com/ballerina-platform/ballerina-standard-library/issues/2604)
+
+## [2.1.0] - 2021-12-14
+
 ### Fixed
 - [Notify user of Subscription denial from the `hub` when `onSubscriptionDenied` is not implemented](https://github.com/ballerina-platform/ballerina-standard-library/issues/2448)  
 

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/websub/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/websub/CompilerPluginTest.java
@@ -375,6 +375,17 @@ public class CompilerPluginTest {
         Assert.assertEquals(errorDiagnostics.size(), 0);
     }
 
+    @Test
+    public void testValidWebsubServiceDeclarationWithIntersectionTypes() {
+        Package currentPackage = loadPackage("sample_23");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        List<Diagnostic> errorDiagnostics = diagnosticResult.diagnostics().stream()
+                .filter(d -> DiagnosticSeverity.ERROR.equals(d.diagnosticInfo().severity()))
+                .collect(Collectors.toList());
+        Assert.assertEquals(errorDiagnostics.size(), 0);
+    }
+
     private Package loadPackage(String path) {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve(path);
         BuildProject project = BuildProject.load(getEnvironmentBuilder(), projectDirPath);

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_23/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_23/Ballerina.toml
@@ -1,0 +1,7 @@
+[package]
+org = "websub_test"
+name = "sample_23"
+version = "0.1.0"
+
+[build-options]
+observabilityIncluded = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_23/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_23/service.bal
@@ -1,0 +1,30 @@
+// Copyright (c) 2022 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/websub;
+
+@websub:SubscriberServiceConfig{}
+service /sample on new websub:Listener(10001) {
+    remote function onEventNotification(readonly & websub:ContentDistributionMessage event)
+                        returns websub:Acknowledgement|websub:SubscriptionDeletedError? {
+        return websub:ACKNOWLEDGEMENT;
+    }
+
+    remote function onUnsubscriptionVerification(readonly & websub:UnsubscriptionVerification event)
+                        returns websub:UnsubscriptionVerificationSuccess|websub:UnsubscriptionVerificationError {
+        return websub:UNSUBSCRIPTION_VERIFICATION_SUCCESS;
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/websub/task/AnalyserUtils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/websub/task/AnalyserUtils.java
@@ -21,6 +21,7 @@ package io.ballerina.stdlib.websub.task;
 import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.symbols.ErrorTypeSymbol;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
+import io.ballerina.compiler.api.symbols.IntersectionTypeSymbol;
 import io.ballerina.compiler.api.symbols.ModuleSymbol;
 import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
@@ -109,6 +110,13 @@ public final class AnalyserUtils {
                     .filter(e -> !e.isEmpty() && !e.isBlank())
                     .reduce((a, b) -> String.join("|", a, b)).orElse("");
             return optionalSymbolAvailable ? concatenatedTypeDesc + Constants.OPTIONAL : concatenatedTypeDesc;
+        } else if (TypeDescKind.INTERSECTION.equals(paramKind)) {
+            List<TypeSymbol> availableTypes = ((IntersectionTypeSymbol) paramType).memberTypeDescriptors();
+            return availableTypes.stream()
+                    .filter(e -> TypeDescKind.TYPE_REFERENCE.equals(e.typeKind()))
+                    .map(AnalyserUtils::getTypeDescription)
+                    .filter(e -> !e.isEmpty() && !e.isBlank())
+                    .reduce((a, b) -> String.join("&", a, b)).orElse("");
         } else if (TypeDescKind.ERROR.equals(paramKind)) {
             return getErrorTypeDescription(paramType);
         } else {

--- a/native/src/main/java/io/ballerina/stdlib/websub/Constants.java
+++ b/native/src/main/java/io/ballerina/stdlib/websub/Constants.java
@@ -29,12 +29,23 @@ public interface Constants {
     String PACKAGE_NAME = "websub";
 
     String SERVICE_OBJECT = "WEBSUB_SERVICE_OBJECT";
+    String PARAM_TYPES = "PARAMETER_TYPES";
     String HTTP_REQUEST = "HTTP_REQUEST";
 
     String SERVICE_PATH = "SERVICE_PATH";
     String SERVICE_REGISTRY = "SERVICE_REGISTRY";
     String SERVICE_INFO_REGISTRY = "SERVICE_INFO_REGISTRY";
     String SUBSCRIBER_CONFIG = "SUBSCRIBER_CONFIG";
+
+    String ON_SUBSCRIPTION_VERIFICATION = "onSubscriptionVerification";
+    String ON_UNSUBSCRIPTION_VERIFICATION = "onUnsubscriptionVerification";
+    String ON_SUBSCRIPTION_VALIDATION_DENIED = "onSubscriptionValidationDenied";
+    String ON_EVENT_NOTIFICATION = "onEventNotification";
+
+    String SUBSCRIPTION_DENIED_ERROR = "SubscriptionDeniedError";
+    String SUBSCRIPTION_VERIFICATION = "SubscriptionVerification";
+    String UNSUBSCRIPTION_VERIFICATION = "UnsubscriptionVerification";
+    String CONTENT_DISTRIBUTION_MSG = "ContentDistributionMessage";
 
     String ANN_NAME_HTTP_INTROSPECTION_DOC_CONFIG = "IntrospectionDocConfig";
     BString ANN_FIELD_DOC_NAME = StringUtils.fromString("name");

--- a/native/src/main/java/io/ballerina/stdlib/websub/Constants.java
+++ b/native/src/main/java/io/ballerina/stdlib/websub/Constants.java
@@ -29,7 +29,6 @@ public interface Constants {
     String PACKAGE_NAME = "websub";
 
     String SERVICE_OBJECT = "WEBSUB_SERVICE_OBJECT";
-    String PARAM_TYPES = "PARAMETER_TYPES";
     String HTTP_REQUEST = "HTTP_REQUEST";
 
     String SERVICE_PATH = "SERVICE_PATH";
@@ -41,11 +40,6 @@ public interface Constants {
     String ON_UNSUBSCRIPTION_VERIFICATION = "onUnsubscriptionVerification";
     String ON_SUBSCRIPTION_VALIDATION_DENIED = "onSubscriptionValidationDenied";
     String ON_EVENT_NOTIFICATION = "onEventNotification";
-
-    String SUBSCRIPTION_DENIED_ERROR = "SubscriptionDeniedError";
-    String SUBSCRIPTION_VERIFICATION = "SubscriptionVerification";
-    String UNSUBSCRIPTION_VERIFICATION = "UnsubscriptionVerification";
-    String CONTENT_DISTRIBUTION_MSG = "ContentDistributionMessage";
 
     String ANN_NAME_HTTP_INTROSPECTION_DOC_CONFIG = "IntrospectionDocConfig";
     BString ANN_FIELD_DOC_NAME = StringUtils.fromString("name");


### PR DESCRIPTION
## Purpose
> $subject

Related to [#2604](https://github.com/ballerina-platform/ballerina-standard-library/issues/2604)

## Examples
With this change developers could use `reaonly` parameters for remote methods in `websub:SubscriberService`:
```ballerina
@SubscriberServiceConfig {
    target: "https://discover.hub/discovery",
    leaseSeconds: 36000
}
service /subscriber on subListener {
    isolated remote function onSubscriptionValidationDenied(readonly & websub:SubscriptionDeniedError msg) returns websub:Acknowledgement? {
        // implement logic here
        return websub:ACKNOWLEDGEMENT;
    }

    remote function onUnsubscriptionVerification(readonly & websub:UnsubscriptionVerification msg)
                    returns websub:UnsubscriptionVerificationSuccess|websub:UnsubscriptionVerificationError {
        if (msg.hubTopic == "test1") {
            return websub:UNSUBSCRIPTION_VERIFICATION_ERROR;
        } else {
            return websub:UNSUBSCRIPTION_VERIFICATION_SUCCESS;
        }
    }

    isolated remote function onSubscriptionVerification(readonly & websub:SubscriptionVerification msg)
                        returns websub:SubscriptionVerificationSuccess|websub:SubscriptionVerificationError {
        if (msg.hubTopic == "test1") {
            return websub:SUBSCRIPTION_VERIFICATION_ERROR;
        } else {
            return websub:SUBSCRIPTION_VERIFICATION_SUCCESS;
        }
    }

    isolated remote function onEventNotification(readonly & websub:ContentDistributionMessage event)
                        returns websub:Acknowledgement|websub:SubscriptionDeletedError? {
        // implement logic here
        return websub:ACKNOWLEDGEMENT;
    }
}
```

## Checklist
- [X] Linked to an issue
- [X] Updated the changelog
- [X] Added tests
