### PR TITLE
Allow running `websub:SubscriberService` by providing the callback URL without providing the service-path

### DIFF
--- a/ballerina-tests/tests/service_path_generation_disabled_test.bal
+++ b/ballerina-tests/tests/service_path_generation_disabled_test.bal
@@ -17,21 +17,24 @@
 import ballerina/test;
 import ballerina/websub;
 
-listener websub:Listener testListener = new (10001);
+listener websub:Listener pathGenDisabledListener1 = new (10002);
 
-@websub:SubscriberServiceConfig {} 
-service on testListener {
+@websub:SubscriberServiceConfig {
+    callback: "http://localhost:10002"
+}
+service on pathGenDisabledListener1 {
     remote function onEventNotification(websub:ContentDistributionMessage message)
                 returns websub:Acknowledgement|websub:SubscriptionDeletedError? {
         return websub:ACKNOWLEDGEMENT;
     }
 }
 
+listener websub:Listener pathGenDisabledListener2 = new (10003);
+
 @websub:SubscriberServiceConfig {
-    callback: "http://localhost:10001",
-    appendServicePath: true
+    callback: "http://localhost:10003"
 }
-service on testListener {
+service / on pathGenDisabledListener2 {
     remote function onEventNotification(websub:ContentDistributionMessage message)
                 returns websub:Acknowledgement|websub:SubscriptionDeletedError? {
         return websub:ACKNOWLEDGEMENT;
@@ -41,6 +44,7 @@ service on testListener {
 @test:Config { 
     groups: ["integrationTest"]
 }
-function testServicePathAutoGeneration() returns error? {
-    check testListener.gracefulStop();
+function testServicePathAutoGenerationDisabled() returns error? {
+    check pathGenDisabledListener1.gracefulStop();
+    check pathGenDisabledListener2.gracefulStop();
 }

--- a/ballerina-tests/tests/service_path_generation_test.bal
+++ b/ballerina-tests/tests/service_path_generation_test.bal
@@ -38,6 +38,16 @@ service on testListener {
     }
 }
 
+@websub:SubscriberServiceConfig {
+    callback: "http://localhost:10001"
+}
+service on testListener {
+    remote function onEventNotification(websub:ContentDistributionMessage message)
+                returns websub:Acknowledgement|websub:SubscriptionDeletedError? {
+        return websub:ACKNOWLEDGEMENT;
+    }
+}
+
 @test:Config { 
     groups: ["integrationTest"]
 }

--- a/ballerina/commons.bal
+++ b/ballerina/commons.bal
@@ -32,7 +32,7 @@ const string ACCEPT_LANGUAGE_HEADER = "Accept-Language";
 const string CONTENT_TYPE = "Content-Type";
 const string X_HUB_SIGNATURE = "X-Hub-Signature";
 
-const string COMMON_SERVICE_PATH = "subscriber";
+const string COMMON_SERVICE_PATH = "/";
 
 const string SHA1 = "sha1";
 const string SHA_256 = "sha256";

--- a/ballerina/sub_listener.bal
+++ b/ballerina/sub_listener.bal
@@ -97,7 +97,7 @@ public class Listener {
                                     string[]|string? name = ()) returns error? {
         boolean generateServicePath = shouldUseGeneratedServicePath(serviceConfig, name);
         string[]|string? servicePath = generateServicePath ? check self.retrieveGeneratedServicePath(serviceConfig): name;
-        string completeSevicePath = check retrieveCompleteServicePath(servicePath);
+        string completeSevicePath = retrieveCompleteServicePath(servicePath);
         string callback = constructCallbackUrl(serviceConfig, self.port, self.listenerConfig,
                                                 completeSevicePath, generateServicePath);
         HttpToWebsubAdaptor adaptor = new ('service);
@@ -291,14 +291,14 @@ isolated function isEmptyServicePath(string[]|string? name) returns boolean {
     return name is () || (name is string[] && name.length() == 0);
 }
 
-isolated function retrieveCompleteServicePath(string[]|string? servicePath) returns string|Error {
+isolated function retrieveCompleteServicePath(string[]|string? servicePath) returns string {
     if servicePath is () {
-        return error Error("Could not find the generated service path");
+        return COMMON_SERVICE_PATH;
     } else if servicePath is string {
         return servicePath.startsWith("/") ? servicePath.substring(1): servicePath;
     } else {
         if servicePath.length() == 0 {
-            return error Error("Could not find the generated service path");
+            return COMMON_SERVICE_PATH;
         } else {
             return strings:'join("/", ...servicePath);
         }

--- a/ballerina/tests/utils_test.bal
+++ b/ballerina/tests/utils_test.bal
@@ -180,24 +180,16 @@ isolated function testServicePathGenerationEnabledWithCallbackAppendingAndServic
     groups: ["completeServicePathRetrieval"]
 }
 isolated function testServicePathRetrievalForEmptyServicePath() {
-    var servicePath = retrieveCompleteServicePath(());
-    if servicePath is error {
-        test:assertEquals(servicePath.message(), "Could not find the generated service path");
-    } else {
-        test:assertFail("Retrieved a service-path for a errorneous scenario");
-    }
+    string servicePath = retrieveCompleteServicePath(());
+    test:assertEquals(servicePath, COMMON_SERVICE_PATH);
 }
 
 @test:Config {
     groups: ["completeServicePathRetrieval"]
 }
 isolated function testServicePathRetrievalForEmptyServicePathArr() {
-    var servicePath = retrieveCompleteServicePath([]);
-    if servicePath is error {
-        test:assertEquals(servicePath.message(), "Could not find the generated service path");
-    } else {
-        test:assertFail("Retrieved a service-path for a errorneous scenario");
-    }
+    string servicePath = retrieveCompleteServicePath([]);
+    test:assertEquals(servicePath, COMMON_SERVICE_PATH);
 }
 
 @test:Config { 
@@ -205,7 +197,7 @@ isolated function testServicePathRetrievalForEmptyServicePathArr() {
 }
 isolated function testCompleteServicePathRetrievalWithString() returns error? {
     string expectedServicePath = "subscriber";
-    string generatedServicePath = check retrieveCompleteServicePath("subscriber");
+    string generatedServicePath = retrieveCompleteServicePath("subscriber");
     test:assertEquals(generatedServicePath, expectedServicePath, "Generated service-path does not matched expected service-path"); 
 }
 
@@ -214,7 +206,7 @@ isolated function testCompleteServicePathRetrievalWithString() returns error? {
 }
 isolated function testCompleteServicePathRetrievalWithStringArray() returns error? {
     string expectedServicePath = "subscriber/foo/bar";
-    string generatedServicePath = check retrieveCompleteServicePath(["subscriber", "foo", "bar"]);
+    string generatedServicePath = retrieveCompleteServicePath(["subscriber", "foo", "bar"]);
     test:assertEquals(generatedServicePath, expectedServicePath, "Generated service-path does not matched expected service-path"); 
 }
 

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - [Incorporate compiler-plugin code-generators to unique service path generation logic](https://github.com/ballerina-platform/ballerina-standard-library/issues/2487)
+- [Cannot run `websub:SubscriberService` by providing the callback URL without providing the service-path](https://github.com/ballerina-platform/ballerina-standard-library/issues/2932)
 
 ## [2.2.0] - 2022-01-29
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -280,6 +280,7 @@ should be `websub:SubscriberServiceConfig` a service-level-annotation for `websu
 # + unsubscribeOnShutdown - This flag notifies whether or not to initiate unsubscription when the service is shutting down
 # + httpConfig - The configuration for the hub client used to interact with the discovered/specified hub
 # + discoveryConfig - HTTP client configurations for resource discovery
+# + servicePath - The generated service-path if the service-path is not provided. This is auto-generated at the compile-time
 public type SubscriberServiceConfiguration record {|
     string|[string, string] target?;
     int leaseSeconds?;
@@ -293,6 +294,7 @@ public type SubscriberServiceConfiguration record {|
         string|string[] acceptLanguage?;
         http:ClientConfiguration httpConfig?;
     |} discoveryConfig?;
+    readonly byte[] servicePath = [];
 |};
 ```
 
@@ -315,9 +317,7 @@ Service path generation should be implemented with following guidelines:
 - Service path should be generated only if;
   - Service path and callback URL is not provided for the `websub:SubscriberService`.
   - callback URL is provided, `appendServicePath` configuration is enabled and service path is not provided.
-- WebSub compiler plugin should generate the unique service path for the `websub:SubscriberService`.
-- Generated service path should be saved in relation to service ID in `service-info.csv`.
-- `service-info.csv` file should be added to `resources/ballerina/websub` directory inside the executable JAR as well as the thin JAR.
+- WebSub compiler plugin will generate unique service path for the `websub:SubscriberService` and populate `servicePath` field in `websub:SubscriberServiceConfig` annotation.
 - If there is an error while generating the service path, then it should result in a compile-time error since this feature is required to generate a callback URL and without it subscriber service could not be used.
 
 #### 2.2.4. Unsubscribing from the `hub`

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -319,7 +319,7 @@ Service path generation should be implemented with following guidelines:
   - callback URL is provided, `appendServicePath` configuration is enabled and service path is not provided.
 - WebSub compiler plugin will generate unique service path for the `websub:SubscriberService` and populate `servicePath` field in `websub:SubscriberServiceConfig` annotation.
 - If there is an error while generating the service path, then it should result in a compile-time error since this feature is required to generate a callback URL and without it subscriber service could not be used.
-- If the developer has provided the callback URL without providing the service path then the `websub:SubscriberService` will be attached to the default service path which is `/`.
+- If the callback URL is provided without the service path then the `websub:SubscriberService` will be attached to the default service path which is `/`.
 
 #### 2.2.4. Unsubscribing from the `hub`
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -319,6 +319,7 @@ Service path generation should be implemented with following guidelines:
   - callback URL is provided, `appendServicePath` configuration is enabled and service path is not provided.
 - WebSub compiler plugin will generate unique service path for the `websub:SubscriberService` and populate `servicePath` field in `websub:SubscriberServiceConfig` annotation.
 - If there is an error while generating the service path, then it should result in a compile-time error since this feature is required to generate a callback URL and without it subscriber service could not be used.
+- If the developer has provided the callback URL without providing the service path then the `websub:SubscriberService` will be attached to the default service path which is `/`.
 
 #### 2.2.4. Unsubscribing from the `hub`
 


### PR DESCRIPTION
## Purpose
> $subject

Fixes [#2932](https://github.com/ballerina-platform/ballerina-standard-library/issues/2932)

## Examples
With this fix following code-segment should work properly:
```ballerina

import ballerina/log;
import ballerina/websub;

@websub:SubscriberServiceConfig {
    target: ["https://sample.hub.com", "https://sample.topic.com"],
    callback: "https://sample.subscriber.com"
}
service on new websub:Listener(9091) {
    remote function onEventNotification(readonly & websub:ContentDistributionMessage msg) returns websub:Acknowledgement {
        log:printInfo("Received content update: ", payload = msg);
        return websub:ACKNOWLEDGEMENT;
    }
}
```

## Checklist
- [X] Linked to an issue
- [x] Updated the changelog
- [X] Added tests
- [x] Updated the spec
