### PR TITLE
Allow running `websub:SubscriberService` by providing the callback URL without providing the service-path

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "websub"
-version = "2.2.1"
+version = "2.2.2"
 authors = ["Ballerina"]
 keywords = ["websub", "subscriber", "service", "listener"]
 repository = "https://github.com/ballerina-platform/module-ballerina-websub"
@@ -10,4 +10,4 @@ license = ["Apache-2.0"]
 distribution = "2201.0.1"
 
 [[platform.java11.dependency]]
-path = "../native/build/libs/websub-native-2.2.1.jar"
+path = "../native/build/libs/websub-native-2.2.2-SNAPSHOT.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "websub-compiler-plugin"
 class = "io.ballerina.stdlib.websub.WebSubCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/websub-compiler-plugin-2.2.1.jar"
+path = "../compiler-plugin/build/libs/websub-compiler-plugin-2.2.2-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -44,8 +44,9 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
+	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "os"},
@@ -204,7 +205,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -229,7 +230,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.0.2"
+version = "1.0.4"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -314,7 +315,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "websub"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "http"},

--- a/ballerina/commons.bal
+++ b/ballerina/commons.bal
@@ -32,7 +32,7 @@ const string ACCEPT_LANGUAGE_HEADER = "Accept-Language";
 const string CONTENT_TYPE = "Content-Type";
 const string X_HUB_SIGNATURE = "X-Hub-Signature";
 
-const string COMMON_SERVICE_PATH = "subscriber";
+const string COMMON_SERVICE_PATH = "/";
 
 const string SHA1 = "sha1";
 const string SHA_256 = "sha256";

--- a/ballerina/sub_listener.bal
+++ b/ballerina/sub_listener.bal
@@ -102,7 +102,7 @@ public class Listener {
                                     string[]|string? name = ()) returns error? {
         boolean generateServicePath = shouldUseGeneratedServicePath(serviceConfig, name);
         string[]|string? servicePath = generateServicePath ? check self.retrieveGeneratedServicePath('service): name;
-        string completeSevicePath = check retrieveCompleteServicePath(servicePath);
+        string completeSevicePath = retrieveCompleteServicePath(servicePath);
         string callback = constructCallbackUrl(serviceConfig, self.port, self.listenerConfig,
                                                 completeSevicePath, generateServicePath);
         HttpToWebsubAdaptor adaptor = new ('service);
@@ -288,14 +288,14 @@ isolated function isEmptyServicePath(string[]|string? name) returns boolean {
     return name is () || (name is string[] && name.length() == 0);
 }
 
-isolated function retrieveCompleteServicePath(string[]|string? servicePath) returns string|Error {
+isolated function retrieveCompleteServicePath(string[]|string? servicePath) returns string {
     if servicePath is () {
-        return error Error("Could not find the generated service path");
+        return COMMON_SERVICE_PATH;
     } else if servicePath is string {
         return servicePath.startsWith("/") ? servicePath.substring(1): servicePath;
     } else {
         if servicePath.length() == 0 {
-            return error Error("Could not find the generated service path");
+            return COMMON_SERVICE_PATH;
         } else {
             return strings:'join("/", ...servicePath);
         }

--- a/ballerina/tests/subscriber_with_opt_service_path_test.bal
+++ b/ballerina/tests/subscriber_with_opt_service_path_test.bal
@@ -1,0 +1,67 @@
+// Copyright (c) 2022 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/log;
+import ballerina/lang.runtime;
+import ballerina/test;
+
+isolated boolean subscriptionVerified = false;
+
+listener Listener subscriberWithoutServicePathListener = new (9105);
+
+SubscriberService subscriberWithoutServicePath = @SubscriberServiceConfig {
+    target: "http://127.0.0.1:9191/common/discovery",
+    callback: "http://localhost:9105",
+    leaseSeconds: 36000
+}
+service object {
+    isolated remote function onSubscriptionVerification(SubscriptionVerification msg) returns SubscriptionVerificationSuccess {
+        lock {
+            subscriptionVerified = true;
+        }
+        log:printInfo("onSubscriptionVerification invoked");
+        return SUBSCRIPTION_VERIFICATION_SUCCESS;
+    }
+
+    isolated remote function onEventNotification(ContentDistributionMessage event) returns Acknowledgement {
+        log:printInfo("onEventNotification invoked ", contentDistributionMessage = event);
+        return ACKNOWLEDGEMENT;
+    }
+};
+
+@test:BeforeGroups { value:["subscriberWithoutServicePath"] }
+function beforeSubscriberWithoutServicePathTest() returns error? {
+    runtime:sleep(5);
+    log:printInfo("Initializing subscriber service");
+    check subscriberWithoutServicePathListener.attach(subscriberWithoutServicePath, ());
+}
+
+@test:AfterGroups { value:["subscriberWithoutServicePath"] }
+function afterSubscriberWithoutServicePathTest() returns error? {
+    check subscriberWithoutServicePathListener.gracefulStop();
+}
+
+@test:Config { 
+    groups: ["subscriberWithoutServicePath"]
+}
+function testSubscriptionWithoutServicePath() returns error? {
+    runtime:sleep(5);
+    boolean verified = false;
+    lock {
+        verified = subscriptionVerified;
+    }
+    test:assertTrue(verified, "Subscription verification was unssuccessfull");
+}

--- a/ballerina/tests/subscriber_with_opt_service_path_test.bal
+++ b/ballerina/tests/subscriber_with_opt_service_path_test.bal
@@ -47,6 +47,7 @@ function beforeSubscriberWithoutServicePathTest() returns error? {
     runtime:sleep(5);
     log:printInfo("Initializing subscriber service");
     check subscriberWithoutServicePathListener.attach(subscriberWithoutServicePath, ());
+    check subscriberWithoutServicePathListener.'start();
 }
 
 @test:AfterGroups { value:["subscriberWithoutServicePath"] }

--- a/ballerina/tests/subscriber_with_opt_service_path_test.bal
+++ b/ballerina/tests/subscriber_with_opt_service_path_test.bal
@@ -45,7 +45,6 @@ service object {
 @test:BeforeGroups { value:["subscriberWithoutServicePath"] }
 function beforeSubscriberWithoutServicePathTest() returns error? {
     runtime:sleep(5);
-    log:printInfo("Initializing subscriber service");
     check subscriberWithoutServicePathListener.attach(subscriberWithoutServicePath, ());
     check subscriberWithoutServicePathListener.'start();
 }

--- a/ballerina/tests/test_init.bal
+++ b/ballerina/tests/test_init.bal
@@ -16,7 +16,6 @@
 
 import ballerina/test;
 import ballerina/http;
-import ballerina/log;
 
 listener http:Listener simpleHttpServiceListener = new (9191);
 

--- a/ballerina/tests/test_init.bal
+++ b/ballerina/tests/test_init.bal
@@ -31,8 +31,8 @@ http:Service simpleHttpService = service object {
 
     isolated resource function post hub(http:Caller caller, http:Request request) returns error? {
         log:printInfo("Received subscription request", details = request.getQueryParams());
-        string? callbackUrl = request.getQueryParamValue(HUB_CALLBACK);
         check caller->respond();
+        string? callbackUrl = request.getQueryParamValue(HUB_CALLBACK);
         if callbackUrl is string {
             http:Client httpClient = check new (callbackUrl);
             http:Response response = check httpClient->get("/?hub.mode=subscribe&hub.topic=https://sample.topic.com&hub.challenge=1234");
@@ -45,6 +45,7 @@ http:Service simpleHttpService = service object {
 function beforeSuiteFunc() returns error? {
     log:printInfo("Initializing discovery service");
     check simpleHttpServiceListener.attach(simpleHttpService, "/common");
+    check simpleHttpServiceListener.'start();
 }
 
 @test:AfterSuite { }

--- a/ballerina/tests/test_init.bal
+++ b/ballerina/tests/test_init.bal
@@ -22,7 +22,6 @@ listener http:Listener simpleHttpServiceListener = new (9191);
 
 http:Service simpleHttpService = service object {
     isolated resource function get discovery(http:Caller caller, http:Request request) returns error? {
-        log:printInfo("Received discovery request");
         http:Response response = new;
         response.addHeader("Link", "<http://127.0.0.1:9191/common/hub>; rel=\"hub\"");
         response.addHeader("Link", "<https://sample.topic.com>; rel=\"self\"");
@@ -30,20 +29,16 @@ http:Service simpleHttpService = service object {
     }
 
     isolated resource function post hub(http:Caller caller, http:Request request) returns error? {
-        log:printInfo("Received subscription request", details = request.getQueryParams());
+        map<string> params = check request.getFormParams();
         check caller->respond();
-        string? callbackUrl = request.getQueryParamValue(HUB_CALLBACK);
-        if callbackUrl is string {
-            http:Client httpClient = check new (callbackUrl);
-            http:Response response = check httpClient->get("/?hub.mode=subscribe&hub.topic=https://sample.topic.com&hub.challenge=1234");
-            log:printInfo("Response received", status = response.statusCode);
-        }
+        string callbackUrl = params.get(HUB_CALLBACK);
+        http:Client httpClient = check new (callbackUrl);
+        http:Response response = check httpClient->get("/?hub.mode=subscribe&hub.topic=https://sample.topic.com&hub.challenge=1234");
     }
 };
 
 @test:BeforeSuite
 function beforeSuiteFunc() returns error? {
-    log:printInfo("Initializing discovery service");
     check simpleHttpServiceListener.attach(simpleHttpService, "/common");
     check simpleHttpServiceListener.'start();
 }

--- a/ballerina/tests/utils_test.bal
+++ b/ballerina/tests/utils_test.bal
@@ -180,24 +180,16 @@ isolated function testServicePathGenerationEnabledWithCallbackAppendingAndServic
     groups: ["completeServicePathRetrieval"]
 }
 isolated function testServicePathRetrievalForEmptyServicePath() {
-    var servicePath = retrieveCompleteServicePath(());
-    if servicePath is error {
-        test:assertEquals(servicePath.message(), "Could not find the generated service path");
-    } else {
-        test:assertFail("Retrieved a service-path for a errorneous scenario");
-    }
+    string servicePath = retrieveCompleteServicePath(());
+    test:assertEquals(servicePath, COMMON_SERVICE_PATH);
 }
 
 @test:Config {
     groups: ["completeServicePathRetrieval"]
 }
 isolated function testServicePathRetrievalForEmptyServicePathArr() {
-    var servicePath = retrieveCompleteServicePath([]);
-    if servicePath is error {
-        test:assertEquals(servicePath.message(), "Could not find the generated service path");
-    } else {
-        test:assertFail("Retrieved a service-path for a errorneous scenario");
-    }
+    string servicePath = retrieveCompleteServicePath([]);
+    test:assertEquals(servicePath, COMMON_SERVICE_PATH);
 }
 
 @test:Config { 
@@ -205,7 +197,7 @@ isolated function testServicePathRetrievalForEmptyServicePathArr() {
 }
 isolated function testCompleteServicePathRetrievalWithString() returns error? {
     string expectedServicePath = "subscriber";
-    string generatedServicePath = check retrieveCompleteServicePath("subscriber");
+    string generatedServicePath = retrieveCompleteServicePath("subscriber");
     test:assertEquals(generatedServicePath, expectedServicePath, "Generated service-path does not matched expected service-path"); 
 }
 
@@ -214,7 +206,7 @@ isolated function testCompleteServicePathRetrievalWithString() returns error? {
 }
 isolated function testCompleteServicePathRetrievalWithStringArray() returns error? {
     string expectedServicePath = "subscriber/foo/bar";
-    string generatedServicePath = check retrieveCompleteServicePath(["subscriber", "foo", "bar"]);
+    string generatedServicePath = retrieveCompleteServicePath(["subscriber", "foo", "bar"]);
     test:assertEquals(generatedServicePath, expectedServicePath, "Generated service-path does not matched expected service-path"); 
 }
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -319,6 +319,7 @@ Service path generation should be implemented with following guidelines:
 - Generated service path should be saved in relation to service ID in `service-info.csv`.
 - `service-info.csv` file should be added to `resources/ballerina/websub` directory inside the executable JAR as well as the thin JAR.
 - If there is an error while generating the service path, then it should result in a compile-time error since this feature is required to generate a callback URL and without it subscriber service could not be used.
+- If the callback URL is provided without the service path then the `websub:SubscriberService` will be attached to the default service path which is `/`.
 
 #### 2.2.4. Unsubscribing from the `hub`
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -3,7 +3,7 @@
 _Owners_: @shafreenAnfar @chamil321 @ayeshLK    
 _Reviewers_: @chamil321    
 _Created_: 2022/01/31  
-_Updated_: 2022/02/17  
+_Updated_: 2022/05/20  
 _Edition_: Swan Lake  
 _Issue_: [#786](https://github.com/ballerina-platform/ballerina-standard-library/issues/786)
 


### PR DESCRIPTION
## Purpose
> $subject

Related to [#2932](https://github.com/ballerina-platform/ballerina-standard-library/issues/2932)

## Examples
With this fix following code-segment should work properly:
```ballerina

import ballerina/log;
import ballerina/websub;

@websub:SubscriberServiceConfig {
    target: ["https://sample.hub.com", "https://sample.topic.com"],
    callback: "https://sample.subscriber.com"
}
service on new websub:Listener(9091) {
    remote function onEventNotification(readonly & websub:ContentDistributionMessage msg) returns websub:Acknowledgement {
        log:printInfo("Received content update: ", payload = msg);
        return websub:ACKNOWLEDGEMENT;
    }
}
```

## Checklist
- [X] Linked to an issue
- [ ] Updated the changelog
- [X] Added tests
- [x] Updated the spec