### PR TITLE
[FIX] WebSub subscriber service results in panic with service path not found

### DIFF
--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -23,7 +23,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "cache"
-version = "3.4.0"
+version = "3.3.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "constraint"},

--- a/ballerina-tests/tests/service_path_generation_test.bal
+++ b/ballerina-tests/tests/service_path_generation_test.bal
@@ -38,6 +38,14 @@ service on testListener {
     }
 }
 
+@websub:SubscriberServiceConfig {}
+service / on testListener {
+    remote function onEventNotification(websub:ContentDistributionMessage message)
+                returns websub:Acknowledgement|websub:SubscriptionDeletedError? {
+        return websub:ACKNOWLEDGEMENT;
+    }
+}
+
 @test:Config { 
     groups: ["integrationTest"]
 }

--- a/ballerina/sub_listener.bal
+++ b/ballerina/sub_listener.bal
@@ -96,7 +96,6 @@ public class Listener {
     isolated function executeAttach(SubscriberService 'service, SubscriberServiceConfiguration serviceConfig,
                                     string[]|string? name = ()) returns error? {
         boolean generateServicePath = shouldUseGeneratedServicePath(serviceConfig, name);
-        log:printInfo("Service path details", servicePath = name, shouldGenerate = generateServicePath);
         string[]|string? servicePath = generateServicePath ? check self.retrieveGeneratedServicePath(serviceConfig): name;
         string completeSevicePath = retrieveCompleteServicePath(servicePath);
         string callback = constructCallbackUrl(serviceConfig, self.port, self.listenerConfig,
@@ -279,17 +278,16 @@ isolated function constructCallbackUrl(SubscriberServiceConfiguration subscriber
 }
 
 isolated function shouldUseGeneratedServicePath(SubscriberServiceConfiguration subscriberConfig,
-                                                string[]|string? name) returns boolean {
-    if subscriberConfig?.callback is () && isEmptyServicePath(name) {
+                                                string[]|string? servicePath) returns boolean {
+    // if the provided service-path is `()` it is considered as an empty service-path.
+    // if the provided service-path is an empty-array that means the absolute-service path is set to `/`
+    // For more information refer: https://github.com/ballerina-platform/ballerina-spec/issues/810
+    if subscriberConfig?.callback is () && servicePath is () {
         return true;
     }
     return subscriberConfig?.callback is string 
             && subscriberConfig.appendServicePath 
-            && isEmptyServicePath(name);
-}
-
-isolated function isEmptyServicePath(string[]|string? name) returns boolean {
-    return name is () || (name is string[] && name.length() == 0);
+            && servicePath is ();
 }
 
 isolated function retrieveCompleteServicePath(string[]|string? servicePath) returns string {

--- a/ballerina/sub_listener.bal
+++ b/ballerina/sub_listener.bal
@@ -96,6 +96,7 @@ public class Listener {
     isolated function executeAttach(SubscriberService 'service, SubscriberServiceConfiguration serviceConfig,
                                     string[]|string? name = ()) returns error? {
         boolean generateServicePath = shouldUseGeneratedServicePath(serviceConfig, name);
+        log:printInfo("Service path details", servicePath = name, shouldGenerate = generateServicePath);
         string[]|string? servicePath = generateServicePath ? check self.retrieveGeneratedServicePath(serviceConfig): name;
         string completeSevicePath = retrieveCompleteServicePath(servicePath);
         string callback = constructCallbackUrl(serviceConfig, self.port, self.listenerConfig,

--- a/ballerina/tests/utils_test.bal
+++ b/ballerina/tests/utils_test.bal
@@ -115,9 +115,9 @@ isolated function testServicePathGenerationEnabledForCallbackAndEmptyServicePath
 @test:Config {
     groups: ["servicePathGenerationEnabled"]
 }
-isolated function testServicePathGenerationEnabledForNoCallbackAndEmptyServicePathArrProvided() {
+isolated function testServicePathGenerationDisabledForNoCallbackAndEmptyServicePathArrProvided() {
     boolean shouldGenerate = shouldUseGeneratedServicePath({}, []);
-    test:assertTrue(shouldGenerate);
+    test:assertFalse(shouldGenerate);
 }
 
 @test:Config {
@@ -147,9 +147,9 @@ isolated function testServicePathGenerationEnabledWithoutCallbackAppendingAndEmp
 @test:Config {
     groups: ["servicePathGenerationEnabled"]
 }
-isolated function testServicePathGenerationEnabledWithCallbackAppendingAndEmptyServicePathArrProvided() {
+isolated function testServicePathGenerationDisabledWithCallbackAppendingAndEmptyServicePathArrProvided() {
     boolean shouldGenerate = shouldUseGeneratedServicePath({ callback: "https://sample.com/sub", appendServicePath: true }, []);
-    test:assertTrue(shouldGenerate);
+    test:assertFalse(shouldGenerate);
 }
 
 @test:Config {

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- [WebSub subscriber service results in panic with `service path not found`](https://github.com/ballerina-platform/ballerina-standard-library/issues/2882)
+
 ### Changed
 - [API Docs Updated](https://github.com/ballerina-platform/ballerina-standard-library/issues/3463)
 


### PR DESCRIPTION
## Purpose
When attaching a WebSub subscriber-service to a WebSub listener if the attach-point is provided as `/` the subscriber-service initiation failed with a panic. The issue for this is when a service is attached to `/` path ballerina-runtime will assign an empty array to denote the service-path, which in current logic determines as an empty service-path and try to retrieve the auto-generated  service-path which is not available. 

Ballerina runtime behavior is clarified in ballerina-lang issue [#29960](https://github.com/ballerina-platform/ballerina-lang/issues/29960) and ballerina-spec issue [#810](https://github.com/ballerina-platform/ballerina-spec/issues/810). 

So, updated the logic that if the service-path provided to the listener attach method is an empty array, then to consider that service path should not be auto-generated.

Fixes [#2882](https://github.com/ballerina-platform/ballerina-standard-library/issues/2882)

## Examples
N/A

## Checklist
- [X] Linked to an issue
- [X] Updated the changelog
- [X] Added tests
- [ ] ~Updated the spec~
- [ ] ~Checked native-image compatibility~
