### PR TITLE
Fix compiler plugin validation not allowing listener port to be a pre-defined variable

### DIFF
--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.9.0-20240410-095500-2653a74d"
+distribution-version = "2201.9.0-20240425-195200-d5ce8c72"
 
 [[package]]
 org = "ballerina"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.9.0-20240410-095500-2653a74d"
+distribution-version = "2201.9.0-20240425-195200-d5ce8c72"
 
 [[package]]
 org = "ballerina"

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- [`websub` compiler plugin does not allow listener port to be a pre-defined variable](https://github.com/ballerina-platform/ballerina-library/issues/6339)
+
+## [2.10.0] - 2023-09-18
+
 ### Added
 - [Introduce new `ClientConfiguration` record to be used for `websub:SubscriptionClient` and `websub:DiscoveryService`](https://github.com/ballerina-platform/ballerina-standard-library/issues/4706)
 

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/websub/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/websub/CompilerPluginTest.java
@@ -403,6 +403,17 @@ public class CompilerPluginTest {
         Assert.assertEquals(diagnostic.message(), expectedCode.getDescription());
     }
 
+    @Test
+    public void testCompilerPluginForListenerInitWithPortConfig() {
+        Package currentPackage = loadPackage("sample_25");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        List<Diagnostic> errorDiagnostics = diagnosticResult.diagnostics().stream()
+                .filter(d -> DiagnosticSeverity.ERROR.equals(d.diagnosticInfo().severity()))
+                .toList();
+        Assert.assertEquals(errorDiagnostics.size(), 0);
+    }
+
     private Package loadPackage(String path) {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve(path);
         BuildProject project = BuildProject.load(getEnvironmentBuilder(), projectDirPath);

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_25/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_25/Ballerina.toml
@@ -1,0 +1,7 @@
+[package]
+org = "websub_test"
+name = "sample_25"
+version = "0.1.0"
+
+[build-options]
+observabilityIncluded = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_25/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_25/service.bal
@@ -1,0 +1,43 @@
+// Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/websub;
+
+configurable int port = 9090;
+
+listener websub:Listener ln = check new(port, {
+    secureSocket: {
+        key: {
+            path: "tests/resources/ballerinaKeystore.pkcs12",
+            password: "ballerina"
+        }
+    }
+});
+
+@websub:SubscriberServiceConfig {
+}
+service /sample on new websub:Listener(port, {
+    secureSocket: {
+        key: {
+            path: "tests/resources/ballerinaKeystore.pkcs12",
+            password: "ballerina"
+        }
+    }
+}) {
+    remote function onEventNotification(websub:ContentDistributionMessage event) {
+        return;
+    }
+}

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_25/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_25/service.bal
@@ -27,6 +27,26 @@ listener websub:Listener ln = check new(port, {
     }
 });
 
+listener websub:Listener ln2 = check new(listenTo = port, config = {
+    secureSocket: {
+        key: {
+            path: "tests/resources/ballerinaKeystore.pkcs12",
+            password: "ballerina"
+        }
+    }
+});
+
+listener websub:Listener ln3 = check new(listenTo = port);
+
+listener websub:Listener ln4 = check new(listenTo = 9090, config = {
+    secureSocket: {
+        key: {
+            path: "tests/resources/ballerinaKeystore.pkcs12",
+            password: "ballerina"
+        }
+    }
+});
+
 @websub:SubscriberServiceConfig {
 }
 service /sample on new websub:Listener(port, {


### PR DESCRIPTION
## Purpose
> $subject

Part of: [#6339](https://github.com/ballerina-platform/ballerina-library/issues/6339)

## Examples
Allow following listener declaration:
```ballerina
int port = 9000;

# WebSub listener
listener websub:Listener ln = new(port, host = os:getEnv("HOSTNAME"));
```
## Checklist
- [X] Linked to an issue
- [X] Updated the changelog
- [X] Added tests
- [ ] ~Updated the spec~
- [ ] ~Checked native-image compatibility~
