### PR TITLE
Sync the changelog after the release

### DIFF
--- a/ballerina-tests/Ballerina.toml
+++ b/ballerina-tests/Ballerina.toml
@@ -1,10 +1,10 @@
 [package]
 org = "ballerina"
 name = "websub_tests"
-version = "2.15.0"
+version = "2.15.1"
 
 [platform.java21]
 graalvmCompatible = true
 
 [[platform.java21.dependency]]
-path = "../native/build/libs/websub-native-2.15.0.jar"
+path = "../native/build/libs/websub-native-2.15.1-SNAPSHOT.jar"

--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -350,7 +350,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "websub_tests"
-version = "2.15.0"
+version = "2.15.1"
 dependencies = [
 	{org = "ballerina", name = "test"},
 	{org = "ballerina", name = "websub"}

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "websub"
-version = "2.15.0"
+version = "2.15.1"
 authors = ["Ballerina"]
 keywords = ["websub", "subscriber", "service", "listener"]
 repository = "https://github.com/ballerina-platform/module-ballerina-websub"
@@ -15,5 +15,5 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "websub-native"
-version = "2.15.0"
-path = "../native/build/libs/websub-native-2.15.0.jar"
+version = "2.15.1"
+path = "../native/build/libs/websub-native-2.15.1-SNAPSHOT.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "websub-compiler-plugin"
 class = "io.ballerina.stdlib.websub.WebSubCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/websub-compiler-plugin-2.15.0.jar"
+path = "../compiler-plugin/build/libs/websub-compiler-plugin-2.15.1-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -348,7 +348,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "websub"
-version = "2.15.0"
+version = "2.15.1"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "http"},

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.15.0] - 2026-03-12
+
 ### Added
 - [Introduce a mechanism to notify subscribers when there is an when invoking the `onSubscriptionIntentVerified` method on `hub`](https://github.com/ballerina-platform/ballerina-library/issues/8681)
 


### PR DESCRIPTION
## Purpose
> $subject


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request synchronizes the project configuration and documentation following the release of version 2.15.1 of the WebSub module. The changes update version references and dependency paths across all configuration files to reflect the new release version.

## Changes

**Version Updates:**
- Incremented package versions from 2.15.0 to 2.15.1 in all Ballerina configuration files (main module and test suite)

**Dependency Path Updates:**
- Updated native artifact paths to use the new version:
  - `websub-native-2.15.1-SNAPSHOT.jar`
  - `websub-compiler-plugin-2.15.1-SNAPSHOT.jar`
- Updated GraalVM dependency version reference to match the new release version

**Documentation:**
- Added release entry in changelog for version 2.15.0 (dated 2026-03-12) documenting the ability to notify subscribers when `onSubscriptionIntentVerified` is invoked on the hub

**Files Modified:**
- `ballerina-tests/Ballerina.toml`
- `ballerina-tests/Dependencies.toml`
- `ballerina/Ballerina.toml`
- `ballerina/CompilerPlugin.toml`
- `ballerina/Dependencies.toml`
- `changelog.md`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->