### PR TITLE
docs: fix typo 'Successfull' to 'Successful' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ function validateRequest(websub:ContentDistributionMessage event) returns boolea
 | onSubscriptionValidationDenied | Successfull acknowledgement|
 | onSubscriptionVerification | Subscription verification failure|
 | onUnsubscriptionVerification | Unsubscription verification failure|
-| onEventNotification | Successfull acknowledgement|
+| onEventNotification | Successful acknowledgement|
 
 ## Issues and projects 
 


### PR DESCRIPTION
## Purpose
Fixed spelling typos in `README.md` (`Successfull` -> `Successful` and trailing parenthesis fix). 
Submitting this contribution as a prerequisite for the WSO2 Engineering Internship program.

## Examples
N/A (Documentation fix only)

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [x] Updated the spec
- [x] Checked native-image compatibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Corrected the “Successful” spelling in the README’s `onEventNotification` error-handling table.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->