### PR TITLE
Update header formatting in README.md

### DIFF
--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -2,7 +2,7 @@
 
 This module provides APIs for a [WebSub](https://www.w3.org/TR/websub/) Subscriber Service, an implementation of the [WebSub Subscriber](https://www.w3.org/TR/websub/#subscriber) role that discovers a resource's hub and topic, subscribes to updates, and accepts content distribution requests.
 
-## Key Features
+### Key Features
 
 - WebSub Subscriber Service for subscribing to and receiving content updates
 - Automatic hub and topic URL discovery for a given resource URL


### PR DESCRIPTION
## Purpose

Fixes the README so the WSO2 Integration Store correctly displays the Key Features section for this connector. `## Key Features` is demoted to `### Key Features`, nesting it under `## Overview` to match the Store's existing parsing convention.

## Examples

N/A — documentation-only change, no code or behavior affected.

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
- [ ] Checked the impact on OpenAPI generation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Changed the `Key Features` heading in `ballerina/README.md` from level 2 to level 3.
- Nested the section under `Overview` for correct WSO2 Integration Store parsing and display.
- Documentation-only change. No code or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->